### PR TITLE
Get tests running on travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - "if [ \"$PHPCS_TEST\" = \"1\" ]; then pyrus install pear/PHP_CodeSniffer; fi"
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - composer validate
   - composer install --prefer-dist
   - composer require silverstripe/framework:4.0.x-dev silverstripe/config:1.0.x-dev --prefer-dist
   - "if [ \"$DB\" = \"PGSQL\" ]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi"
@@ -33,7 +34,6 @@ before_script:
 script:
   - "if [ \"$PHPUNIT_TEST\" = \"1\" ]; then vendor/bin/phpunit; fi"
   - "if [ \"$PHPCS_TEST\" = \"1\" ]; then composer run-script lint; fi"
-  - "if [ \"$PHPCS_TEST\" = \"1\" ]; then composer validate; fi"
   - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi"
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
   "scripts": {
     "lint": "phpcs --standard=tests/phpcs/ruleset.xml src/ tests/php/"
   },
-  "min-stability": "dev",
+  "minimum-stability": "dev",
   "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,6 @@
 
 	<testsuite name="Default">
 		<directory>tests/php</directory>
-        <directory>framework/tests/php</directory>
     </testsuite>
 
 	<listeners>

--- a/src/AssetControlExtension.php
+++ b/src/AssetControlExtension.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Assets;
 
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\DBFile;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Versioning\Versioned;
@@ -162,7 +163,9 @@ class AssetControlExtension extends DataExtension
         // Unauthenticated member to use for checking visibility
         $baseClass = $this->owner->baseClass();
         $baseTable = $this->owner->baseTable();
-        $filter = array("\"{$baseTable}\".\"ID\"" => $this->owner->ID);
+        $filter = array(
+            Convert::symbol2sql("{$baseTable}.ID") => $this->owner->ID,
+        );
         $stages = $this->owner->getVersionedStages(); // {@see Versioned::getVersionedStages}
         foreach ($stages as $stage) {
             // Skip current stage; These should be handled explicitly


### PR DESCRIPTION
- Move `composer validate` up to `before_script` because if we get composer errors during the install this could flag the problems early
- fix `min-stability` -> `minimum-stability`
- Removing framework test suite