### PR TITLE
Remove CMS specific API from Folder

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -231,25 +231,6 @@ class Folder extends File
     {
         return $this->ChildFolders()->count();
     }
-    /**
-     * @return string
-     */
-    public function CMSTreeClasses()
-    {
-        $classes = sprintf('class-%s', $this->class);
-
-        if (!$this->canDelete()) {
-            $classes .= " nodelete";
-        }
-
-        if (!$this->canEdit()) {
-            $classes .= " disabled";
-        }
-
-        $classes .= $this->markingClasses('numChildFolders');
-
-        return $classes;
-    }
 
     /**
      * @return string


### PR DESCRIPTION
CMSTreeClass method has been refactored into a cms-module specific method.

Dependency of https://github.com/silverstripe/silverstripe-framework/pull/6792