### PR TITLE
FIX: Add PHP extension requirements to composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,15 @@
     }
   ],
   "require": {
-    "silverstripe/framework": "^4@dev"
+    "silverstripe/framework": "^4@dev",
+    "php": ">=5.6.0"
   },
   "require-dev": {
     "silverstripe/versioned": "^1@dev",
     "phpunit/PHPUnit": "~4.8"
+  },
+  "suggest": {
+    "ext-gd": "*"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
    
This will raise incompatibilities sooner rather than relying on the
installer.

All of the other required extensions are included in framework.