### PR TITLE
MINOR: Make filesize maths consistent, remove decimals for KB

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1009,19 +1009,16 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer, Thumb
         if ($size < 1024) {
             return $size . ' bytes';
         }
-        if ($size < 1024*10) {
-            return (round($size/1024*10)/10). ' KB';
-        }
         if ($size < 1024*1024) {
             return round($size/1024) . ' KB';
         }
         if ($size < 1024*1024*10) {
-            return (round(($size/1024)/1024*10)/10) . ' MB';
+            return round(($size/(1024*1024))*10)/10 . ' MB';
         }
         if ($size < 1024*1024*1024) {
-            return round(($size/1024)/1024) . ' MB';
+            return round($size/(1024*1024)) . ' MB';
         }
-        return round($size/(1024*1024*1024)*10)/10 . ' GB';
+        return round(($size/(1024*1024*1024))*10)/10 . ' GB';
     }
 
     /**

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -447,7 +447,7 @@ class FileTest extends SapphireTest
         $this->assertEquals("1000 bytes", File::format_size(1000));
         $this->assertEquals("1023 bytes", File::format_size(1023));
         $this->assertEquals("1 KB", File::format_size(1025));
-        $this->assertEquals("9.8 KB", File::format_size(10000));
+        $this->assertEquals("10 KB", File::format_size(10000));
         $this->assertEquals("49 KB", File::format_size(50000));
         $this->assertEquals("977 KB", File::format_size(1000000));
         $this->assertEquals("1 MB", File::format_size(1024*1024));


### PR DESCRIPTION
This is to make the maths in the JS and PHP for calculating file size consistent, which involves clarifying order of operations and removing decimals for <1MB files.

**Related PR:** https://github.com/silverstripe/silverstripe-admin/pull/35
**Related Issue:** https://github.com/silverstripe/silverstripe-asset-admin/issues/355