### PR TITLE
API Rename services to match FQN of interface / classes

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -2,16 +2,21 @@ fileExtensions:
   - php
 mappings:
   SilverStripe\Filesystem\Storage\AssetContainer: SilverStripe\Assets\Storage\AssetContainer
+  AssetNameGenerator: SilverStripe\Assets\Storage\AssetNameGenerator
   SilverStripe\Filesystem\Storage\AssetNameGenerator: SilverStripe\Assets\Storage\AssetNameGenerator
+  AssetStore: SilverStripe\Assets\Storage\AssetStore
   SilverStripe\Filesystem\Storage\AssetStore: SilverStripe\Assets\Storage\AssetStore
   SilverStripe\Filesystem\Storage\AssetStoreRouter: SilverStripe\Assets\Storage\AssetStoreRouter
   SilverStripe\Filesystem\Storage\DBFile: SilverStripe\Assets\Storage\DBFile
   SilverStripe\Filesystem\Storage\DefaultAssetNameGenerator: SilverStripe\Assets\Storage\DefaultAssetNameGenerator
+  GeneratedAssetHandler: SilverStripe\Assets\Storage\GeneratedAssetHandler
   SilverStripe\Filesystem\Storage\GeneratedAssetHandler: SilverStripe\Assets\Storage\GeneratedAssetHandler
   SilverStripe\Filesystem\Storage\ProtectedFileController: SilverStripe\Assets\Storage\ProtectedFileController
+  ProtectedFileController: SilverStripe\Assets\Storage\ProtectedFileController
   SilverStripe\Filesystem\Flysystem\AssetAdapter: SilverStripe\Assets\Flysystem\AssetAdapter
   SilverStripe\Filesystem\Flysystem\FlysystemAssetStore: SilverStripe\Assets\Flysystem\FlysystemAssetStore
-  SilverStripe\Filesystem\Storage\FlysystemGeneratedAssetHandler: SilverStripe\Assets\Flysystem\GeneratedAssetHandler
+  SilverStripe\Filesystem\Storage\FlysystemGeneratedAssetHandler: SilverStripe\Assets\Flysystem\GeneratedAssets
+  SilverStripe\Assets\Flysystem\GeneratedAssetHandler: SilverStripe\Assets\Flysystem\GeneratedAssets
   SilverStripe\Filesystem\Flysystem\ProtectedAdapter: SilverStripe\Assets\Flysystem\ProtectedAdapter
   SilverStripe\Filesystem\Flysystem\ProtectedAssetAdapter: SilverStripe\Assets\Flysystem\ProtectedAssetAdapter
   SilverStripe\Filesystem\Flysystem\PublicAdapter: SilverStripe\Assets\Flysystem\PublicAdapter
@@ -59,6 +64,10 @@ mappings:
   ImagickImageTest: SilverStripe\Assets\Tests\ImagickImageTest
   AssetStoreTest_SpyStore: SilverStripe\Assets\Tests\Storage\AssetStoreTest\TestAssetStore
   AssetAdapterTest: SilverStripe\Assets\Tests\Flysystem\AssetAdapterTest
+  FlysystemPublicAdapter: SilverStripe\Assets\Flysystem\PublicAdapter
+  FlysystemProtectedAdapter: SilverStripe\Assets\Flysystem\ProtectedAdapter
+  FlysystemPublicBackend: League\Flysystem\Filesystem.public
+  FlysystemProtectedBackend: League\Flysystem\Filesystem.protected
 skipConfigs:
   - db
   - casting

--- a/_config/asset.yml
+++ b/_config/asset.yml
@@ -3,23 +3,23 @@ Name: assetsflysystem
 ---
 SilverStripe\Core\Injector\Injector:
   # Define the default adapter for this filesystem
-  FlysystemPublicAdapter:
-    class: 'SilverStripe\Assets\Flysystem\PublicAssetAdapter'
+  SilverStripe\Assets\Flysystem\PublicAdapter:
+    class: SilverStripe\Assets\Flysystem\PublicAssetAdapter
   # Define the secondary adapter for protected assets
-  FlysystemProtectedAdapter:
-    class: 'SilverStripe\Assets\Flysystem\ProtectedAssetAdapter'
+  SilverStripe\Assets\Flysystem\ProtectedAdapter:
+    class: SilverStripe\Assets\Flysystem\ProtectedAssetAdapter
   # Define the default filesystem
-  FlysystemPublicBackend:
-    class: 'League\Flysystem\Filesystem'
+  League\Flysystem\Filesystem.public:
+    class: League\Flysystem\Filesystem
     constructor:
-      Adapter: '%$FlysystemPublicAdapter'
+      Adapter: %$SilverStripe\Assets\Flysystem\PublicAdapter
       Config:
         visibility: public
   # Define the secondary filesystem for protected assets
-  FlysystemProtectedBackend:
-    class: 'League\Flysystem\Filesystem'
+  League\Flysystem\Filesystem.protected:
+    class: League\Flysystem\Filesystem
     constructor:
-      Adapter: '%$FlysystemProtectedAdapter'
+      Adapter: %$SilverStripe\Assets\Flysystem\ProtectedAdapter
       Config:
         visibility: private
 ---
@@ -27,23 +27,23 @@ Name: assetscore
 ---
 SilverStripe\Core\Injector\Injector:
   # Define our SS asset backend
-  AssetStore:
-    class: 'SilverStripe\Assets\Flysystem\FlysystemAssetStore'
+  SilverStripe\Assets\Storage\AssetStore:
+    class: SilverStripe\Assets\Flysystem\FlysystemAssetStore
     properties:
-      PublicFilesystem: '%$FlysystemPublicBackend'
-      ProtectedFilesystem: '%$FlysystemProtectedBackend'
-  ProtectedFileController:
-    class: SilverStripe\Assets\Storage\ProtectedFileController
+      PublicFilesystem: %$League\Flysystem\Filesystem.public
+      ProtectedFilesystem: %$League\Flysystem\Filesystem.protected
+  SilverStripe\Assets\Storage\AssetStoreRouter: %$SilverStripe\Assets\Storage\AssetStore
+  SilverStripe\Assets\Storage\ProtectedFileController:
     properties:
-      RouteHandler: '%$AssetStore'
-  AssetNameGenerator:
+      RouteHandler: %$SilverStripe\Assets\Storage\AssetStoreRouter
+  SilverStripe\Assets\Storage\AssetNameGenerator:
     class: SilverStripe\Assets\Storage\DefaultAssetNameGenerator
     type: prototype
   # Requirements config
-  GeneratedAssetHandler:
-    class: SilverStripe\Assets\Flysystem\GeneratedAssetHandler
+  SilverStripe\Assets\Storage\GeneratedAssetHandler:
+    class: SilverStripe\Assets\Flysystem\GeneratedAssets
     properties:
-      Filesystem: '%$FlysystemPublicBackend'
+      Filesystem: %$League\Flysystem\Filesystem.public
   SilverStripe\View\Requirements_Backend:
     properties:
-      AssetHandler: '%$GeneratedAssetHandler'
+      AssetHandler: %$SilverStripe\Assets\Storage\GeneratedAssetHandler

--- a/_config/image.yml
+++ b/_config/image.yml
@@ -4,4 +4,3 @@ Name: assetsimage
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Assets\Image_Backend:
     class: SilverStripe\Assets\GDBackend
-  Image_Backend: '%$SilverStripe\Assets\Image_Backend'

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -3,4 +3,4 @@ Name: assetsroutes
 ---
 SilverStripe\Control\Director:
   rules:
-    'assets': ProtectedFileController
+    'assets': SilverStripe\Assets\Storage\ProtectedFileController

--- a/src/AssetControlExtension.php
+++ b/src/AssetControlExtension.php
@@ -302,6 +302,6 @@ class AssetControlExtension extends DataExtension
      */
     protected function getAssetStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -813,7 +813,7 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer, Thumb
      */
     protected function getNameGenerator($filename)
     {
-        return Injector::inst()->createWithArgs('AssetNameGenerator', array($filename));
+        return Injector::inst()->createWithArgs(AssetNameGenerator::class, [$filename]);
     }
 
     /**

--- a/src/Flysystem/AssetAdapter.php
+++ b/src/Flysystem/AssetAdapter.php
@@ -6,7 +6,6 @@ use League\Flysystem\Adapter\Local;
 use League\Flysystem\Config as FlysystemConfig;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Filesystem;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;

--- a/src/Flysystem/GeneratedAssets.php
+++ b/src/Flysystem/GeneratedAssets.php
@@ -3,14 +3,15 @@
 namespace SilverStripe\Assets\Flysystem;
 
 use Exception;
+use League\Flysystem\File;
 use League\Flysystem\Filesystem;
+use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 
 /**
  * Simple Flysystem implementation of GeneratedAssetHandler for storing generated content
  */
-class GeneratedAssetHandler implements \SilverStripe\Assets\Storage\GeneratedAssetHandler
+class GeneratedAssets implements GeneratedAssetHandler
 {
-
     /**
      * Flysystem store for files
      *
@@ -51,10 +52,14 @@ class GeneratedAssetHandler implements \SilverStripe\Assets\Storage\GeneratedAss
         if (!$result) {
             return null;
         }
-        /** @var PublicAdapter $adapter */
-        $adapter = $this
-            ->getFilesystem()
-            ->getAdapter();
+        $filesystem = $this->getFilesystem();
+        if (! $filesystem instanceof Filesystem) {
+            return null;
+        }
+        $adapter = $filesystem->getAdapter();
+        if (!$adapter instanceof PublicAdapter) {
+            return null;
+        }
         return $adapter->getPublicUrl($filename);
     }
 
@@ -109,6 +114,7 @@ class GeneratedAssetHandler implements \SilverStripe\Assets\Storage\GeneratedAss
     public function removeContent($filename)
     {
         if ($this->getFilesystem()->has($filename)) {
+            /** @var File $handler */
             $handler = $this->getFilesystem()->get($filename);
             $handler->delete();
         }

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -591,7 +591,7 @@ trait ImageManipulation
 
         // Create backend for this object
         /** @skipUpgrade */
-        return Injector::inst()->createWithArgs('Image_Backend', array($this));
+        return Injector::inst()->createWithArgs(Image_Backend::class, array($this));
     }
 
     /**
@@ -788,7 +788,7 @@ trait ImageManipulation
 
         // Create this asset in the store if it doesn't already exist,
         // otherwise use the existing variant
-        $store = Injector::inst()->get('AssetStore');
+        $store = Injector::inst()->get(AssetStore::class);
         $result = null;
         if (!$store->exists($filename, $hash, $variant)) {
             $result = call_user_func($callback, $store, $filename, $hash, $variant);

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -78,7 +78,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      */
     protected function getStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 
     private static $composite_db = array(

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -144,7 +144,7 @@ class Upload extends Controller
      */
     protected function getNameGenerator($filename)
     {
-        return Injector::inst()->createWithArgs('AssetNameGenerator', array($filename));
+        return Injector::inst()->createWithArgs(AssetNameGenerator::class, array($filename));
     }
 
     /**
@@ -153,7 +153,7 @@ class Upload extends Controller
      */
     protected function getAssetStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 
     /**

--- a/tests/php/AssetControlExtensionTest.php
+++ b/tests/php/AssetControlExtensionTest.php
@@ -225,6 +225,6 @@ class AssetControlExtensionTest extends SapphireTest
      */
     protected function getAssetStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 }

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -753,6 +753,6 @@ class FileTest extends SapphireTest
      */
     protected function getAssetStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 }

--- a/tests/php/ProtectedFileControllerTest.php
+++ b/tests/php/ProtectedFileControllerTest.php
@@ -14,7 +14,6 @@ use SilverStripe\Assets\Tests\Storage\AssetStoreTest\TestAssetStore;
 
 class ProtectedFileControllerTest extends FunctionalTest
 {
-
     protected static $fixture_file = 'FileTest.yml';
 
     public function setUp()
@@ -26,18 +25,14 @@ class ProtectedFileControllerTest extends FunctionalTest
 
         // Create a test folders for each of the fixture references
         foreach (Folder::get() as $folder) {
-            /**
- * @var Folder $folder
-*/
+            /** @var Folder $folder */
             $filePath = TestAssetStore::getLocalPath($folder);
             Filesystem::makeFolder($filePath);
         }
 
         // Create a test files for each of the fixture references
         foreach (File::get()->exclude('ClassName', Folder::class) as $file) {
-            /**
- * @var File $file
-*/
+            /** @var File $file */
             $path = TestAssetStore::getLocalPath($file);
             Filesystem::makeFolder(dirname($path));
             $fh = fopen($path, "w+");
@@ -200,7 +195,7 @@ class ProtectedFileControllerTest extends FunctionalTest
      */
     protected function getAssetStore()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 
     /**

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -35,7 +35,7 @@ class AssetStoreTest extends SapphireTest
      */
     protected function getBackend()
     {
-        return Injector::inst()->get('AssetStore');
+        return Injector::inst()->get(AssetStore::class);
     }
 
     /**

--- a/tests/php/Storage/AssetStoreTest/TestAssetStore.php
+++ b/tests/php/Storage/AssetStoreTest/TestAssetStore.php
@@ -10,10 +10,13 @@ use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Flysystem\ProtectedAssetAdapter;
 use SilverStripe\Assets\Flysystem\PublicAssetAdapter;
 use SilverStripe\Assets\Storage\AssetContainer;
-use SilverStripe\Assets\Flysystem\GeneratedAssetHandler;
+use SilverStripe\Assets\Flysystem\GeneratedAssets;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Assets\Storage\AssetStoreRouter;
 use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\Requirements;
@@ -71,12 +74,13 @@ class TestAssetStore extends FlysystemAssetStore
         $backend = new TestAssetStore();
         $backend->setPublicFilesystem($publicFilesystem);
         $backend->setProtectedFilesystem($protectedFilesystem);
-        Injector::inst()->registerService($backend, 'AssetStore');
+        Injector::inst()->registerService($backend, AssetStore::class);
+        Injector::inst()->registerService($backend, AssetStoreRouter::class);
 
         // Assign flysystem backend to generated asset handler at the same time
-        $generated = new GeneratedAssetHandler();
+        $generated = new GeneratedAssets();
         $generated->setFilesystem($publicFilesystem);
-        Injector::inst()->registerService($generated, 'GeneratedAssetHandler');
+        Injector::inst()->registerService($generated, GeneratedAssetHandler::class);
         Requirements::backend()->setAssetHandler($generated);
 
         // Disable legacy and set defaults
@@ -136,8 +140,9 @@ class TestAssetStore extends FlysystemAssetStore
         }
         // Extract filesystem used to store this object
         /** @var TestAssetStore $assetStore */
-        $assetStore = Injector::inst()->get('AssetStore');
+        $assetStore = Injector::inst()->get(AssetStore::class);
         $fileID = $assetStore->getFileID($asset->Filename, $asset->Hash, $asset->Variant);
+        /** @var Filesystem $filesystem */
         $filesystem = $assetStore->getProtectedFilesystem();
         if (!$filesystem->has($fileID)) {
             $filesystem = $assetStore->getPublicFilesystem();


### PR DESCRIPTION
Assets PR component for https://github.com/silverstripe/silverstripe-framework/issues/6642

I've renamed the GeneratedAssetHandler to GeneratedAssets so it doesn't differ from the interface simply by namespace. Docs updates are in framework module.

It would be best to merge these changes then restart framework tests at https://github.com/silverstripe/silverstripe-framework/pull/6916