### PR TITLE
NEW Decouple core from GD

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -100,7 +100,10 @@ class Image extends File implements ShortcodeHandler
             HiddenField::create('ID', $this->ID)
         );
 
-        if ($dimensions = $this->getDimensions()) {
+        $width = $this->getWidth();
+        $height = $this->getHeight();
+        if ($width && $height) {
+            $dimensions = sprintf('%dx%d', $width, $height);
             $content->insertAfter(
                 'TitleHeader',
                 LiteralField::create(

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -597,52 +597,13 @@ trait ImageManipulation
     }
 
     /**
-     * Get the dimensions of this Image.
-     *
-     * @param string $dim One of the following:
-     *  - "string": return the dimensions in string form
-     *  - "array": it'll return the raw result
-     *  - 0: return the height
-     *  - 1: return the width
-     * @return string|int|array|null
-     */
-    public function getDimensions($dim = "string")
-    {
-        if (!$this->getIsImage()) {
-            return null;
-        }
-
-        $content = $this->getString();
-        if (!$content) {
-            return null;
-        }
-
-        // Get raw content
-        $size = getimagesizefromstring($content);
-        if ($size === false) {
-            return null;
-        }
-
-        if ($dim === 'array') {
-            return $size;
-        }
-
-        // Get single dimension
-        if (is_numeric($dim)) {
-            return $size[$dim];
-        }
-
-        return "$size[0]x$size[1]";
-    }
-
-    /**
      * Get the width of this image.
      *
      * @return int
      */
     public function getWidth()
     {
-        return $this->getDimensions(0);
+        return $this->getImageBackend()->getWidth();
     }
 
     /**
@@ -652,7 +613,7 @@ trait ImageManipulation
      */
     public function getHeight()
     {
-        return $this->getDimensions(1);
+        return $this->getImageBackend()->getHeight();
     }
 
     /**

--- a/src/Image_Backend.php
+++ b/src/Image_Backend.php
@@ -36,6 +36,16 @@ interface Image_Backend
     public function __construct(AssetContainer $assetContainer = null);
 
     /**
+     * @return int The width of the image
+     */
+    public function getWidth();
+
+    /**
+     * @return int The height of the image
+     */
+    public function getHeight();
+
+    /**
      * Populate the backend with a given object
      *
      * @param AssetContainer $assetContainer Object to load from

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -207,6 +207,22 @@ class InterventionBackend implements Image_Backend, Flushable
     }
 
     /**
+     * @return int The width of the image
+     */
+    public function getWidth()
+    {
+        return $this->getImageResource()->getWidth();
+    }
+
+    /**
+     * @return int The height of the image
+     */
+    public function getHeight()
+    {
+        return $this->getImageResource()->getHeight();
+    }
+
+    /**
      * Set the quality to a value between 0 and 100
      *
      * @param int $quality


### PR DESCRIPTION
`getDimensions` is currently coupled to the GD method `getimagesizefromstring`.

`getDimensions` is also a horrible API which is underused and has no real value given that all of the information it provides is accessible through the `Image_Backend` API or from `File` directly.