### PR TITLE
NEW Add complete list of supported image types

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -189,10 +189,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             'potm', 'potx', 'pps', 'ppt', 'pptx', 'rtf', 'txt', 'xhtml', 'xls', 'xlsx', 'xltm', 'xltx', 'xml',
         ),
         'image' => array(
-            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'tif', 'tiff',
+            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff',
         ),
         'image/supported' => array(
-            'gif', 'jpeg', 'jpg', 'png'
+            'gif', 'jpeg', 'jpg', 'png', 'bmp', 'ico',
         ),
         'flash' => array(
             'fla', 'swf'
@@ -215,6 +215,8 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         'jpeg' => Image::class,
         'png' => Image::class,
         'gif' => Image::class,
+        'bmp' => Image::class,
+        'ico' => Image::class,
     );
 
     /**

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -43,9 +43,28 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      * @var array
      */
     private static $supported_images = array(
+        'image/jpg',
         'image/jpeg',
+        'image/pjpeg',
         'image/gif',
-        'image/png'
+        'image/png',
+        'image/x-png',
+        'image/tiff',
+        'image/tif',
+        'image/x-tiff',
+        'image/x-tif',
+        'image/bmp',
+        'image/ms-bmp',
+        'image/x-bitmap',
+        'image/x-bmp',
+        'image/x-ms-bmp',
+        'image/x-win-bitmap',
+        'image/x-windows-bmp',
+        'image/x-xbitmap',
+        'image/x-ico',
+        'image/x-icon',
+        'image/vnd.microsoft.icon',
+        'image/vnd.adobe.photoshop',
     );
 
     /**

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -204,13 +204,16 @@ class FileTest extends SapphireTest
     {
         // Test specific categories
         $images = array(
-            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'tif', 'tiff'
+            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff'
         );
         $this->assertEquals($images, File::get_category_extensions('image'));
-        $this->assertEquals(array('gif', 'jpeg', 'jpg', 'png'), File::get_category_extensions('image/supported'));
+        $this->assertEquals(
+            array('bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png'),
+            File::get_category_extensions('image/supported')
+        );
         $this->assertEquals($images, File::get_category_extensions(array('image', 'image/supported')));
         $this->assertEquals(
-            array('fla', 'gif', 'jpeg', 'jpg', 'png', 'swf'),
+            array('bmp', 'fla', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'swf'),
             File::get_category_extensions(array('flash', 'image/supported'))
         );
 
@@ -235,9 +238,7 @@ class FileTest extends SapphireTest
 
     public function testSetNameChangesFilesystemOnWrite()
     {
-        /**
-         * @var File $file
-         */
+        /** @var File $file */
         $file = $this->objFromFixture(File::class, 'asdf');
         $this->logInWithPermission('ADMIN');
         $file->publishRecursive();


### PR DESCRIPTION
The `InterventionBackend` supports many more image types - these are now added to the config