### PR TITLE
FIX Catch errors if exif extension not installed

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -153,8 +153,12 @@ class InterventionBackend implements Image_Backend, Flushable
      */
     public function setImageResource($image)
     {
-        // make sure the image is correctly orientated
-        $image->orientate();
+        try {
+            // try to correctly orientate the image based on it's exif data
+            $image->orientate();
+        } catch (NotSupportedException $e) {
+            // noop
+        }
         $this->image = $image;
         return $this;
     }


### PR DESCRIPTION
orientate can throw a `NotSupportedException` if `exif` extension is not available in PHP - this allows us to continue cropping images without having to read exif data.