### PR TITLE
BUG Fix non-images crashing when querying dimensions

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -39,9 +39,9 @@ class Image extends File implements ShortcodeHandler
      */
     private static $plural_name = "Images";
 
-    public function __construct($record = null, $isSingleton = false, $model = null, $queryParams = array())
+    public function __construct($record = null, $isSingleton = false, $queryParams = array())
     {
-        parent::__construct($record, $isSingleton, $model, $queryParams);
+        parent::__construct($record, $isSingleton, $queryParams);
         $this->File->setAllowedCategories('image/supported');
     }
 

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -587,7 +587,8 @@ trait ImageManipulation
      */
     public function getImageBackend()
     {
-        if (!$this->getIsImage()) {
+        // Skip if non-image or file is broken
+        if (!$this->getIsImage() || !$this->exists()) {
             return null;
         }
 
@@ -603,7 +604,11 @@ trait ImageManipulation
      */
     public function getWidth()
     {
-        return $this->getImageBackend()->getWidth();
+        $backend = $this->getImageBackend();
+        if ($backend) {
+            return $backend->getWidth();
+        }
+        return 0;
     }
 
     /**
@@ -613,7 +618,11 @@ trait ImageManipulation
      */
     public function getHeight()
     {
-        return $this->getImageBackend()->getHeight();
+        $backend = $this->getImageBackend();
+        if ($backend) {
+            return $backend->getHeight();
+        }
+        return 0;
     }
 
     /**

--- a/tests/php/GDImageTest.php
+++ b/tests/php/GDImageTest.php
@@ -2,18 +2,15 @@
 
 namespace SilverStripe\Assets\Tests;
 
-require_once __DIR__  . "/ImageTest.php";
-
 use Intervention\Image\ImageManager;
 use SilverStripe\Assets\Image;
+use SilverStripe\Assets\InterventionBackend;
 use SilverStripe\Core\Config\Config;
-use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator;
 
 class GDImageTest extends ImageTest
 {
-
     public function setUp()
     {
         parent::setUp();
@@ -35,7 +32,10 @@ class GDImageTest extends ImageTest
 
     public function testDriverType()
     {
+        /** @var Image $image */
         $image = $this->objFromFixture(Image::class, 'imageWithTitle');
-        $this->assertEquals('gd', $image->getImageBackend()->getImageManager()->config['driver']);
+        /** @var InterventionBackend $backend */
+        $backend = $image->getImageBackend();
+        $this->assertEquals('gd', $backend->getImageManager()->config['driver']);
     }
 }

--- a/tests/php/ImagickImageTest.php
+++ b/tests/php/ImagickImageTest.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Assets\Tests;
 
 use Intervention\Image\ImageManager;
 use SilverStripe\Assets\Image;
-use SilverStripe\Assets\ImagickBackend;
+use SilverStripe\Assets\InterventionBackend;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator;
@@ -32,7 +32,10 @@ class ImagickImageTest extends ImageTest
 
     public function testDriverType()
     {
+        /** @var Image $image */
         $image = $this->objFromFixture(Image::class, 'imageWithTitle');
-        $this->assertEquals('imagick', $image->getImageBackend()->getImageManager()->config['driver']);
+        /** @var InterventionBackend $backend */
+        $backend = $image->getImageBackend();
+        $this->assertEquals('imagick', $backend->getImageManager()->config['driver']);
     }
 }


### PR DESCRIPTION
This is needed for graphql since object serialisation doesn't know if an object is an image or not until it's serialised. We need to report 0 for non-image files.