### PR TITLE
BUG Ensure dimensions are cached

### DIFF
--- a/_config/assetscache.yml
+++ b/_config/assetscache.yml
@@ -6,4 +6,3 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "Intervention_Manipulations"
-      defaultLifetime: 100


### PR DESCRIPTION
Fixes #47 

I'll do some benchmarking now, but it seems to work if I run a bunch of pages, and then throw an Exception before loading assets from stream (to prove the image isn't loaded by the Image_Backend).

@sminnee do you want to review?

@dhensby I've refactored loadFromContainer so it doesn't immediately load the file into memory. Instead we wait until absolutely necessary.