### PR TITLE
ENHANCEMENT Support for eventually consistent assets

### DIFF
--- a/tests/php/ImageTest/not-image.txt
+++ b/tests/php/ImageTest/not-image.txt
@@ -1,0 +1,1 @@
+Some non image content


### PR DESCRIPTION
Partial implementation of https://github.com/silverstripe/silverstripe-framework/issues/5544

This enhancement allows us to take different approaches to different error conditions: Missing images (null streams) will approach a backing-off approach to re-attempts, where non-image content will permanently mark a specific file SHA against future attempts.

Both re-attempt durations and backing-off approaches can be customised on a per-error basis.