### PR TITLE
API Implement copy / move at the filesystem level

### DIFF
--- a/src/Storage/AssetContainer.php
+++ b/src/Storage/AssetContainer.php
@@ -151,6 +151,23 @@ interface AssetContainer
     public function deleteFile();
 
     /**
+     * Rename to new filename, and point to new file
+     *
+     * @param string $newName
+     * @return string Updated Filename
+     */
+    public function renameFile($newName);
+
+    /**
+     * Copy to new filename.
+     * This will not automatically point to the new file (as renameFile() does)
+     *
+     * @param string $newName
+     * @return string Updated filename
+     */
+    public function copyFile($newName);
+
+    /**
      * Publicly expose the file (and all variants) identified by the given filename and hash
      * {@see AssetStore::publish}
      */

--- a/src/Storage/AssetStore.php
+++ b/src/Storage/AssetStore.php
@@ -216,6 +216,26 @@ interface AssetStore
     public function delete($filename, $hash);
 
     /**
+     * Rename a file (and all variants) to a new filename
+     *
+     * @param string $filename
+     * @param string $hash
+     * @param string $newName
+     * @return string Updated Filename, or null if rename failed
+     */
+    public function rename($filename, $hash, $newName);
+
+    /**
+     * Copy a file (and all variants) to a new filename
+     *
+     * @param string $filename
+     * @param string $hash
+     * @param string $newName
+     * @return string Updated Filename, or null if copy failed
+     */
+    public function copy($filename, $hash, $newName);
+
+    /**
      * Publicly expose the file (and all variants) identified by the given filename and hash
      *
      * @param string $filename Filename (not including assets)

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -3,14 +3,13 @@
 namespace SilverStripe\Assets\Storage;
 
 use SilverStripe\Assets\File;
-use SilverStripe\Assets\Thumbnail;
 use SilverStripe\Assets\ImageManipulation;
-use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Assets\Thumbnail;
 use SilverStripe\Control\Director;
-use SilverStripe\Forms\FileField;
-use SilverStripe\ORM\ValidationResult;
-use SilverStripe\ORM\ValidationException;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBComposite;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Permission;
 
 /**
@@ -22,7 +21,6 @@ use SilverStripe\Security\Permission;
  */
 class DBFile extends DBComposite implements AssetContainer, Thumbnail
 {
-
     use ImageManipulation;
 
     /**
@@ -578,5 +576,29 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
             && $this
                 ->getStore()
                 ->canView($this->Filename, $this->Hash);
+    }
+
+    public function renameFile($newName)
+    {
+        if (!$this->Filename) {
+            return null;
+        }
+        $newName = $this
+            ->getStore()
+            ->rename($this->Filename, $this->Hash, $newName);
+        if ($newName) {
+            $this->Filename = $newName;
+        }
+        return $newName;
+    }
+
+    public function copyFile($newName)
+    {
+        if (!$this->Filename) {
+            return null;
+        }
+        return $this
+            ->getStore()
+            ->copy($this->Filename, $this->Hash, $newName);
     }
 }

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -304,7 +304,6 @@ class FileTest extends SapphireTest
             $this->getAssetStore()->exists($newTuple['Filename'], $newTuple['Hash']),
             'New path is updated in memory, not written before write() is called'
         );
-        $file->write();
 
         // After write()
         $file->write();
@@ -715,5 +714,22 @@ class FileTest extends SapphireTest
     protected function getAssetStore()
     {
         return Injector::inst()->get(AssetStore::class);
+    }
+
+    public function testRename()
+    {
+        /** @var File $file */
+        $file = $this->objFromFixture(File::class, 'asdf');
+        $this->assertTrue($file->exists());
+        $this->assertEquals('FileTest.txt', $file->getFilename());
+        $this->assertEquals('FileTest.txt', $file->File->getFilename());
+
+        // Rename immediately saves record and moves to new location
+        $result = $file->renameFile('_Parent/New__File.txt');
+        $this->assertTrue($file->exists());
+        $this->assertEquals('Parent/New_File.txt', $result);
+        $this->assertEquals('Parent/New_File.txt', $file->generateFilename());
+        $this->assertEquals('Parent/New_File.txt', $file->getFilename());
+        $this->assertFalse($file->isChanged());
     }
 }

--- a/tests/php/Storage/AssetStoreTest/TestAssetStore.php
+++ b/tests/php/Storage/AssetStoreTest/TestAssetStore.php
@@ -60,14 +60,14 @@ class TestAssetStore extends FlysystemAssetStore
         $publicFilesystem = new Filesystem(
             $publicAdapter,
             [
-            'visibility' => AdapterInterface::VISIBILITY_PUBLIC
+                'visibility' => AdapterInterface::VISIBILITY_PUBLIC
             ]
         );
         $protectedAdapter = new ProtectedAssetAdapter(ASSETS_PATH . '/' . $basedir . '/.protected');
         $protectedFilesystem = new Filesystem(
             $protectedAdapter,
             [
-            'visibility' => AdapterInterface::VISIBILITY_PRIVATE
+                'visibility' => AdapterInterface::VISIBILITY_PRIVATE
             ]
         );
 
@@ -162,6 +162,10 @@ class TestAssetStore extends FlysystemAssetStore
         return parent::getFileID($filename, $hash, $variant);
     }
 
+    public function parseFileID($fileID)
+    {
+        return parent::parseFileID($fileID);
+    }
 
     public function getOriginalFilename($fileID)
     {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/562

I've also added some better tests for string manipulation of file identifier.

Note that this PR introduces two new API methods to both the AssetContainer and AssetStore interfaces; This would introduce a potentially (but low risk) breaking change to beta2.

CC @silverstripe/core-team for approval prior to merge.