### PR TITLE
Image orientation should happen on loading the image resource

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -254,6 +254,14 @@ class InterventionBackend implements Image_Backend, Flushable
                 $this->setTempPath($path);
                 $resource = $this->getImageManager()->make($path);
             }
+
+            // Fix image orientation
+            try {
+                $resource->orientate();
+            } catch (NotSupportedException $e) {
+                // noop - we can't orientate, don't worry about it
+            }
+
             $this->setImageResource($resource);
             $this->markSuccess($hash, $variant);
             $error = null;
@@ -331,13 +339,6 @@ class InterventionBackend implements Image_Backend, Flushable
             $resource = $this->getImageResource();
             if (!$resource) {
                 throw new BadMethodCallException("Cannot write corrupt file to store");
-            }
-
-            // Fix image orientation
-            try {
-                $resource->orientate();
-            } catch (NotSupportedException $e) {
-                // noop - we can't orientate, don't worry about it
             }
 
             // Save file

--- a/tests/php/ImageTest.php
+++ b/tests/php/ImageTest.php
@@ -69,9 +69,18 @@ abstract class ImageTest extends SapphireTest
     public function testAutoOrientateOnEXIFData()
     {
         $image = $this->objFromFixture(Image::class, 'exifPortrait');
-        $this->assertEquals(Image_Backend::ORIENTATION_LANDSCAPE, $image->getOrientation());
+        $this->assertEquals(Image_Backend::ORIENTATION_PORTRAIT, $image->getOrientation());
         $resampled = $image->Resampled();
         $this->assertEquals(Image_Backend::ORIENTATION_PORTRAIT, $resampled->getOrientation());
+    }
+
+    public function testExifOrientationOnManipulatedImage()
+    {
+        /** @var Image $image */
+        $image = $this->objFromFixture(Image::class, 'exifPortrait');
+        $resampled = $image->ScaleHeight(100);
+        $this->assertEquals(Image_Backend::ORIENTATION_PORTRAIT, $resampled->getOrientation());
+        $this->assertEquals(100, $resampled->getHeight());
     }
 
     public function testGetTagWithoutTitle()


### PR DESCRIPTION
Fixes #76 

Image orientation needs to happen when the resource is loaded rather than written otherwise resize operations are performed on an incorrectly orientated image.

Also, orientation can happen multiple times if the same object is written to the store repeatedly.