### PR TITLE
BUG Fix migrations to delete the migrated files

### DIFF
--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\Assets;
 
+use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
@@ -119,6 +121,11 @@ class FileMigrationHelper
         $file->write();
         if (class_exists(Versioned::class)) {
             $file->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
+        }
+
+        if (!Config::inst()->get(FlysystemAssetStore::class, 'legacy_filenames')) {
+            // removing the legacy file since it has been migrated now and not using legacy filenames
+            return unlink($path);
         }
         return true;
     }

--- a/tests/php/FileMigrationHelperTest.php
+++ b/tests/php/FileMigrationHelperTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Assets\Tests;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Assets\FileMigrationHelper;
+use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Tests\FileMigrationHelperTest\Extension;
 use SilverStripe\Core\Config\Config;
@@ -102,5 +103,12 @@ class FileMigrationHelperTest extends SapphireTest
         $invalidID = $this->idFromFixture(File::class, 'invalid');
         $this->assertNotEmpty($invalidID);
         $this->assertNull(File::get()->byID($invalidID));
+    }
+
+    public function testMigrationWithLegacyFilenames()
+    {
+        Config::modify()->set(FlysystemAssetStore::class, 'legacy_filenames', true);
+
+        $this->testMigration();
     }
 }


### PR DESCRIPTION
I've left suppressing the warning messages so that they can be caught in logs/screen and then (hopefully) manually deleted by the admin

Fixes https://github.com/silverstripe/silverstripe-assets/issues/70