### PR TITLE
FIX Remove whitespace around download link title

### DIFF
--- a/templates/DBFile_download.ss
+++ b/templates/DBFile_download.ss
@@ -1,3 +1,1 @@
-<a href="$URL.ATT" title="$Title" <% if $Basename %>download="$Basename.ATT"<% else %>download<% end_if %>>
-    $Title
-</a>
+<a href="$URL.ATT" title="$Title" <% if $Basename %>download="$Basename.ATT"<% else %>download<% end_if %>>$Title</a>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5170590/32573914-85a9d978-c534-11e7-8f2c-2e9b8c519117.png)

After:
![image](https://user-images.githubusercontent.com/5170590/32573898-6fce4de6-c534-11e7-87b6-1e4ffa15a27c.png)

Note: testing with CWP Wātea theme, hence the icon