### PR TITLE
BUG Prevent .htaccess operations from users in the same group failing

### DIFF
--- a/src/Flysystem/AssetAdapter.php
+++ b/src/Flysystem/AssetAdapter.php
@@ -44,11 +44,11 @@ class AssetAdapter extends Local
      */
     private static $file_permissions = array(
         'file' => [
-            'public' => 0644,
+            'public' => 0664,
             'private' => 0600,
         ],
         'dir' => [
-            'public' => 0755,
+            'public' => 0775,
             'private' => 0700,
         ]
     );


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7584

Docs update for this pr at https://github.com/silverstripe/silverstripe-framework/pull/7593

This will address situations where multiple users (e.g. ftp-user / www-user) are in the same group, but cannot modify any file created by the other.