### PR TITLE
ENHANCEMENT Add DBFile::Link() alias for DBFile::getURL() so that it matches File::Link()

### DIFF
--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -278,6 +278,16 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
     }
 
     /**
+     * Return URL for this image. Alias for getURL()
+     *
+     * @return string
+     */
+    public function Link()
+    {
+        return $this->getURL();
+    }
+
+    /**
      * Get URL, but without resampling.
      * Note that this will return the url even if the file does not exist.
      *


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7764

I know this is 4.0 branch, but if it's expected to be there and it isn't it's possibly a bugfix.