### PR TITLE
BUG Ensure CMS authors can all see draft files by default

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -112,12 +112,12 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     private static $plural_name = "Files";
 
     /**
-     * Permissions necessary to view files outside of the live stage (e.g. archive / draft stage).
+     * Anyone with CMS access can view draft files
      *
      * @config
      * @var array
      */
-    private static $non_live_permissions = array('CMS_ACCESS_LeftAndMain', 'CMS_ACCESS_AssetAdmin', 'VIEW_DRAFT_CONTENT');
+    private static $non_live_permissions = ['CMS_ACCESS', 'VIEW_DRAFT_CONTENT'];
 
     private static $db = array(
         "Name" => "Varchar(255)",


### PR DESCRIPTION
Partial fix for https://github.com/silverstripe/silverstripe-asset-admin/issues/730

Because files are used in many places, we allow anyone with CMS permissions to view draft files by default.