### PR TITLE
FIX Typo in "audio file" translation

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -32,7 +32,7 @@ en:
     TOOLARGE: 'Filesize is too large, maximum {size} allowed'
     TiffType: 'Tagged image format'
     URL: URL
-    WavType: 'WAV audo file'
+    WavType: 'WAV audio file'
     XlsType: 'Excel spreadsheet'
     ZipType: 'ZIP compressed file'
   SilverStripe\Assets\Folder:

--- a/src/File.php
+++ b/src/File.php
@@ -897,7 +897,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             'dmg' => _t(__CLASS__.'.DmgType', 'Apple disk image'),
             'pdf' => _t(__CLASS__.'.PdfType', 'Adobe Acrobat PDF file'),
             'mp3' => _t(__CLASS__.'.Mp3Type', 'MP3 audio file'),
-            'wav' => _t(__CLASS__.'.WavType', 'WAV audo file'),
+            'wav' => _t(__CLASS__.'.WavType', 'WAV audio file'),
             'avi' => _t(__CLASS__.'.AviType', 'AVI video file'),
             'mpg' => _t(__CLASS__.'.MpgType', 'MPEG video file'),
             'mpeg' => _t(__CLASS__.'.MpgType', 'MPEG video file'),


### PR DESCRIPTION
Resolves Transifex issue:

>DE ISSUE
>Typo in source string 'audo'. It must be 'audio'.
>by Atalanttore, 9 months ago