### PR TITLE
BUG Loosen constraint to prevent 403 errors on some platforms

### DIFF
--- a/templates/SilverStripe/Assets/Flysystem/PublicAssetAdapter_HTAccess.ss
+++ b/templates/SilverStripe/Assets/Flysystem/PublicAssetAdapter_HTAccess.ss
@@ -25,7 +25,7 @@ AddHandler default-handler php phtml php3 php4 php5 inc
     RewriteRule error[^\\\\/]*\\.html$ - [L]
 
     # Block invalid file extensions
-    RewriteCond %{REQUEST_URI} !^[^.]*\\.(?i:css|js<% loop $AllowedExtensions %>|$Extension<% end_loop %>)$
+    RewriteCond %{REQUEST_URI} !^.*\\.(?i:css|js<% loop $AllowedExtensions %>|$Extension<% end_loop %>)$
     RewriteRule .* - [F]
 
     # Non existant files passed to requesthandler


### PR DESCRIPTION
Related to https://forum.silverstripe.org/t/unable-to-edit-pages-on-a-fresh-install-local-environment/538/8

I've tested the suggested tweak and it does appear to still block invalid extensions.