### PR TITLE
Update recipe branching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 # Install composer dependencies
   - composer validate
   - composer install --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:1.2.x-dev silverstripe/versioned:1.2.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-core:4.2.x-dev silverstripe/versioned:1.2.x-dev
   - composer update --prefer-dist
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.