### PR TITLE
BUG mark legacy migration test as skipped temporarily

### DIFF
--- a/tests/php/FileMigrationHelperTest.php
+++ b/tests/php/FileMigrationHelperTest.php
@@ -107,8 +107,10 @@ class FileMigrationHelperTest extends SapphireTest
 
     public function testMigrationWithLegacyFilenames()
     {
+        // See https://github.com/silverstripe/silverstripe-framework/issues/8182
+        $this->markTestSkipped("Re-enable once DDL no longer breaks test transactional state");
+        return;
         Config::modify()->set(FlysystemAssetStore::class, 'legacy_filenames', true);
-
         $this->testMigration();
     }
 }


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/8182 for issue background.