### PR TITLE
FIX Add HTMLFragment casting to $Tag (#148)

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -157,7 +157,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     );
 
     private static $casting = array (
-        'TreeTitle' => 'HTMLFragment'
+        'TreeTitle' => 'HTMLFragment',
+        'getTreeTitle' => 'HTMLFragment',
+        'Tag' => 'HTMLFragment',
+        'getTag' => 'HTMLFragment',
     );
 
     private static $table_name = 'File';


### PR DESCRIPTION
I messed up the merge on #148. It should have been merge against the `1` branch instead of master.

I just cherry picked that specific commit, so I could do a merge against `1` as well.

* #147 
