### PR TITLE
BUG Keep folder Name and Title in sync on update

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -92,16 +92,9 @@ class Folder extends File
 
     public function onBeforeWrite()
     {
-        // Make sure Title is updated if Name is chaged (as we keep these in sync for folders)
-        if ($this->isChanged('Name')) {
-            $name = $this->Name;
-            $this->setField(
-                'Title',
-                str_replace(array('-','_'), ' ', preg_replace('/\.[^.]+$/', '', $name))
-            );
-        }
-
         parent::onBeforeWrite();
+
+        $this->Title = $this->getField('Name');
     }
 
     /**

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -90,6 +90,20 @@ class Folder extends File
         parent::onBeforeDelete();
     }
 
+    public function onBeforeWrite()
+    {
+        // Make sure Title is updated if Name is chaged (as we keep these in sync for folders)
+        if ($this->isChanged('Name')) {
+            $name = $this->Name;
+            $this->setField(
+                'Title',
+                str_replace(array('-','_'), ' ', preg_replace('/\.[^.]+$/', '', $name))
+            );
+        }
+
+        parent::onBeforeWrite();
+    }
+
     /**
      * Return the relative URL of an icon for this file type
      *

--- a/tests/php/FolderTest.php
+++ b/tests/php/FolderTest.php
@@ -293,6 +293,19 @@ class FolderTest extends SapphireTest
         $newFolder->Title = 'TestTitleWithIllegalCharactersCopiedToName <!BANG!>';
         $this->assertEquals($newFolder->Name, $newFolder->Title);
         $this->assertEquals($newFolder->Title, 'TestTitleWithIllegalCharactersCopiedToName <!BANG!>');
+
+        // Title should be populated from name on first write
+        $writeFolder = new Folder();
+        $writeFolder->Name = 'TestNameWrittenToTitle';
+        $writeFolder->write();
+        $newFolderWritten = Folder::get_one(Folder::class, "\"Title\" = 'TestNameWrittenToTitle'");
+        $this->assertNotNull($newFolderWritten);
+
+        // Title should be populated from name on subsequent writes
+        $writeFolder->Name = 'TestNameWrittenToTitleOnUpdate';
+        $writeFolder->write();
+        $newFolderWritten = Folder::get_one(Folder::class, "\"Title\" = 'TestNameWrittenToTitleOnUpdate'");
+        $this->assertNotNull($newFolderWritten);
     }
 
     public function testRootFolder()


### PR DESCRIPTION
This was discovered while working to improve folder sorting, folders are sorted by Title but when you update their Name through the admin interface it would not update the Title and they would end up out of sync and quietly mess up alphabetical sorting.

**Related but not dependant PR** https://github.com/silverstripe/silverstripe-asset-admin/pull/844