### PR TITLE
FIX: allow base path of /

### DIFF
--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -136,7 +136,7 @@ class FileFinder
     {
         $base = rtrim($base, '/');
         // Special case for a base path of /, eg. a chroot environment
-        if ($base == '') {
+        if ($base === '') {
             $base = '/';
         }
 

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -134,7 +134,13 @@ class FileFinder
      */
     public function find($base)
     {
-        $paths = array(array(rtrim($base, '/'), 0));
+        $base = rtrim($base, '/');
+        // Special case for a base path of /, eg. a chroot environment
+        if ($base == '') {
+            $base = '/';
+        }
+
+        $paths = array(array($base, 0));
         $found = array();
 
         $fileCallback = $this->getOption('file_callback');


### PR DESCRIPTION
A base path of / was sanitised to "", which is illegal.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/1586

Although I don't have a chroot environment in which to test this, a review of the code suggests that this is the only place it's broken.

Note: if there's reluctance to merge this I'd suggest closing the referenced bug as wontfix. I've submitted this principally for the purpose of reducing the number of open bug ticktes.