### PR TITLE
Ensure Versioned exists

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -650,8 +650,11 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     {
         // Force query of draft object and update (as source record is bound to live stage)
         /** @var File $draftRecord */
-        $draftRecord = Versioned::get_by_stage(self::class, Versioned::DRAFT)->byID($this->ID);
-        $draftRecord->updateDependantObjects();
+        if (class_exists(Versioned::class) &&
+            $draftRecord = Versioned::get_by_stage(self::class, Versioned::DRAFT)->byID($this->ID)
+        ) {
+            $draftRecord->updateDependantObjects();
+        }
     }
 
     /**
@@ -660,7 +663,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     protected function updateDependantObjects()
     {
         // Skip live stage
-        if (Versioned::get_stage() === Versioned::LIVE) {
+        if (class_exists(Versioned::class) && Versioned::get_stage() === Versioned::LIVE) {
             return;
         }
 

--- a/src/Shortcodes/FileLinkTracking.php
+++ b/src/Shortcodes/FileLinkTracking.php
@@ -109,7 +109,10 @@ class FileLinkTracking extends DataExtension
     public function augmentSyncLinkTracking()
     {
         // If owner is versioned, skip tracking on live
-        if (Versioned::get_stage() == Versioned::LIVE && $this->owner->hasExtension(Versioned::class)) {
+        if (class_exists(Versioned::class) &&
+            Versioned::get_stage() == Versioned::LIVE &&
+            $this->owner->hasExtension(Versioned::class)
+        ) {
             return;
         }
 
@@ -138,7 +141,10 @@ class FileLinkTracking extends DataExtension
     public function onAfterDelete()
     {
         // If owner is versioned, skip tracking on live
-        if (Versioned::get_stage() == Versioned::LIVE && $this->owner->hasExtension(Versioned::class)) {
+        if (class_exists(Versioned::class) &&
+            Versioned::get_stage() == Versioned::LIVE &&
+            $this->owner->hasExtension(Versioned::class)
+        ) {
             return;
         }
 


### PR DESCRIPTION
Ensure `class_exists(Versioned::class)` exists before calling `Versioned::get_stage()` on `augmentSyncLinkTracking()` and `onAfterDelete()`  - resolves #172