### PR TITLE
MINOR: Change expected type to int, per framework PR change

### DIFF
--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -701,10 +701,10 @@ class FileTest extends SapphireTest
     public function ini2BytesProvider()
     {
         return [
-            ['2k', (float)(2 * 1024)],
-            ['512M', (float)(512 * 1024 * 1024)],
-            ['1024g', (float)(1024 * 1024 * 1024 * 1024)],
-            ['1024G', (float)(1024 * 1024 * 1024 * 1024)]
+            ['2k', (int)(2 * 1024)],
+            ['512M', (int)(512 * 1024 * 1024)],
+            ['1024g', (int)(1024 * 1024 * 1024 * 1024)],
+            ['1024G', (int)(1024 * 1024 * 1024 * 1024)]
         ];
     }
 


### PR DESCRIPTION
This gets the tests passing due to the API change (!!!) in https://github.com/silverstripe/silverstripe-framework/commit/3f321f935a0b7faa3d4ef788b4f69425db979095

A good reminder that even small API changes like that can break stuff silently.