### PR TITLE
FIX Cache key cannot contain : chars, will happen when viewing from archive

### DIFF
--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -173,7 +173,7 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
     {
         $key = SSViewer::config()->get('global_key');
         $viewer = new SSViewer_FromString($key);
-        $globalKey = $viewer->process(ArrayData::create([]));
+        $globalKey = md5($viewer->process(ArrayData::create([])));
         $argsKey = md5(serialize($params)) . '#' . md5(serialize($content));
 
         return "{$globalKey}#{$argsKey}";


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/2340

Needs to be merged up for the 4.3 release