### PR TITLE
FIX: Add missing file upload error types (fixes #205)

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -21,6 +21,7 @@ en:
     MpgType: 'MPEG video file'
     NOFILESIZE: 'Filesize is zero bytes.'
     NOVALIDUPLOAD: 'File is not a valid upload'
+    PARTIALUPLOAD: 'File did not finish uploading, please try again'
     PATH: Path
     PLURALNAME: Files
     PLURALS:

--- a/src/Upload_Validator.php
+++ b/src/Upload_Validator.php
@@ -276,6 +276,14 @@ class Upload_Validator
             return false;
         }
 
+        if (!$this->isCompleteUpload()) {
+            $this->errors[] = _t(
+                'SilverStripe\\Assets\\File.PARTIALUPLOAD',
+                'File did not finish uploading, please try again'
+            );
+            return false;
+        }
+
         // Check file isn't empty
         if ($this->isFileEmpty()) {
             $this->errors[] = _t('SilverStripe\\Assets\\File.NOFILESIZE', 'Filesize is zero bytes.');
@@ -315,7 +323,7 @@ class Upload_Validator
     public function isValidUpload()
     {
         // Check file upload
-        if ($this->tmpFile['error'] === UPLOAD_ERR_NO_FILE) {
+        if (in_array($this->tmpFile['error'], [UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE])) {
             return false;
         }
 
@@ -331,5 +339,15 @@ class Upload_Validator
         }
 
         return true;
+    }
+
+    /**
+     * Check whether the file was fully uploaded
+     *
+     * @return bool
+     */
+    public function isCompleteUpload()
+    {
+        return ($this->tmpFile['error'] !== UPLOAD_ERR_PARTIAL);
     }
 }

--- a/tests/php/UploadTest.php
+++ b/tests/php/UploadTest.php
@@ -249,6 +249,33 @@ class UploadTest extends SapphireTest
             _t('SilverStripe\\Assets\\File.NOVALIDUPLOAD', 'File is not a valid upload'),
             $upload->getErrors()
         );
+
+        // Test no tmp dir
+        $upload->clearErrors();
+        $tmpFile['error'] = UPLOAD_ERR_NO_TMP_DIR;
+        $this->assertFalse($upload->validate($tmpFile));
+        $this->assertContains(
+            _t('SilverStripe\\Assets\\File.NOVALIDUPLOAD', 'File is not a valid upload'),
+            $upload->getErrors()
+        );
+
+        // Test can't write error
+        $upload->clearErrors();
+        $tmpFile['error'] = UPLOAD_ERR_CANT_WRITE;
+        $this->assertFalse($upload->validate($tmpFile));
+        $this->assertContains(
+            _t('SilverStripe\\Assets\\File.NOVALIDUPLOAD', 'File is not a valid upload'),
+            $upload->getErrors()
+        );
+
+        // Test partial file upload
+        $upload->clearErrors();
+        $tmpFile['error'] = UPLOAD_ERR_PARTIAL;
+        $this->assertFalse($upload->validate($tmpFile));
+        $this->assertContains(
+            _t('SilverStripe\\Assets\\File.PARTIALUPLOAD', 'File did not finish uploading, please try again'),
+            $upload->getErrors()
+        );
     }
 
     public function testGetAllowedMaxFileSize()


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/issues/205

Error types reference: http://php.net/manual/en/features.file-upload.errors.php

I added `UPLOAD_ERR_NO_TMP_DIR` and `UPLOAD_ERR_CANT_WRITE` to the generic “not a valid upload” error as I think they’re sufficiently rare to not need their own message: if you don’t have a tmp directory, or can’t write to it, you’re probably going to have bigger fish to fry...