### PR TITLE
MINOR When using legacy filename resolve conflicts by keeping existing file

### DIFF
--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -87,6 +87,8 @@ class FileMigrationHelper
      */
     protected function migrateFile($base, File $file, $legacyFilename)
     {
+        $useLegacyFilenames = Config::inst()->get(FlysystemAssetStore::class, 'legacy_filenames');
+
         // Make sure this legacy file actually exists
         $path = $base . '/' . $legacyFilename;
         if (!file_exists($path)) {
@@ -127,7 +129,11 @@ class FileMigrationHelper
             $filename,
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_OVERWRITE)
+            [
+                'conflict' => $useLegacyFilenames ?
+                    AssetStore::CONFLICT_USE_EXISTING :
+                    AssetStore::CONFLICT_OVERWRITE
+            ]
         );
 
         // Move file if the APL changes filename value
@@ -141,7 +147,7 @@ class FileMigrationHelper
             $file->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         }
 
-        if (!Config::inst()->get(FlysystemAssetStore::class, 'legacy_filenames')) {
+        if (!$useLegacyFilenames) {
             // removing the legacy file since it has been migrated now and not using legacy filenames
             return unlink($path);
         }

--- a/tests/php/FileMigrationHelperTest.php
+++ b/tests/php/FileMigrationHelperTest.php
@@ -17,6 +17,7 @@ use SilverStripe\Dev\SapphireTest;
  */
 class FileMigrationHelperTest extends SapphireTest
 {
+    protected $usesTransactions = false;
 
     protected static $fixture_file = 'FileMigrationHelperTest.yml';
 
@@ -86,6 +87,7 @@ class FileMigrationHelperTest extends SapphireTest
 
         // Test that each file exists
         foreach (File::get()->exclude('ClassName', Folder::class) as $file) {
+            /** @var File $file */
             $expectedFilename = $file->generateFilename();
             $filename = $file->File->getFilename();
             $this->assertTrue($file->exists(), "File with name {$filename} exists");
@@ -97,6 +99,7 @@ class FileMigrationHelperTest extends SapphireTest
                 "File with name {$filename} has the correct hash"
             );
             $this->assertTrue($file->isPublished(), "File is published after migration");
+            $this->assertGreaterThan(0, $file->getAbsoluteSize());
         }
 
         // Ensure that invalid file has been removed during migration
@@ -107,9 +110,6 @@ class FileMigrationHelperTest extends SapphireTest
 
     public function testMigrationWithLegacyFilenames()
     {
-        // See https://github.com/silverstripe/silverstripe-framework/issues/8182
-        $this->markTestSkipped("Re-enable once DDL no longer breaks test transactional state");
-        return;
         Config::modify()->set(FlysystemAssetStore::class, 'legacy_filenames', true);
         $this->testMigration();
     }


### PR DESCRIPTION
When migrating SS3 files with the `legacy_filename` enable, the files would be overridden with 0 bytes file. Basicaly the Migration helper would try to move the file, but the file would already be there because we're using the legacy name.

This change the update conflict resolution strategy to keep the existing file. The non-legacy-filename behaviour will stay the same.

I also restored a test that had been skipped because of https://github.com/silverstripe/silverstripe-framework/issues/8182

# Parent issue
* #188