### PR TITLE
Fix for issue #212

### DIFF
--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -257,7 +257,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
                 throw new InvalidArgumentException("$path could not be opened for reading");
             }
             $result = $filesystem->putStream($fileID, $handle);
-            fclose($handle);
+			if(is_resource($handle)){
+            	fclose($handle);
+			}
             return $result;
         };
 
@@ -450,7 +452,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
             // Copy via stream
             $stream = $from->readStream($nextID);
             $to->putStream($nextID, $stream);
-            fclose($stream);
+			if(is_resource($stream)){
+            	fclose($stream);
+			}
             $from->delete($nextID);
         }
 

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -257,9 +257,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
                 throw new InvalidArgumentException("$path could not be opened for reading");
             }
             $result = $filesystem->putStream($fileID, $handle);
-			if(is_resource($handle)){
-            	fclose($handle);
-			}
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
             return $result;
         };
 
@@ -452,9 +452,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
             // Copy via stream
             $stream = $from->readStream($nextID);
             $to->putStream($nextID, $stream);
-			if(is_resource($stream)){
-            	fclose($stream);
-			}
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
             $from->delete($nextID);
         }
 


### PR DESCRIPTION
Some flysystem modules are automatically closing/deleting the file resource when it is in a temp location and has been uploaded to the remote system.  Due to this we need to check that the resource still exists before attempting to close and causing an error.