### PR TITLE
BUG Redirect legacy file name and older hash url to latest live URL

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -132,6 +132,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         "Owner" => Member::class,
     );
 
+    private static $indexes = array(
+        'FileHash' => true
+    );
+
     private static $defaults = array(
         "ShowInSearch" => 1,
     );

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -815,7 +815,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
     private function parseLegacyFileID($fileID)
     {
         // assets/folder/_resampled/ResizedImageWzEwMCwxMzNd/basename.extension
-        $ss3Pattern = '#^(?<folder>([^/_]+/)*?)(_resampled/(?<variant>([^/.]+))/)?((?<basename>[^/._]+))(?<extension>(\..+)*)$#';
+        $ss3Pattern = '#^(?<folder>([^/_]+/)*?)(_resampled/(?<variant>([^/.]+))/)?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#';
         // assets/folder/basename__ResizedImageWzEwMCwxMzNd.extension
         $ss4LegacyPattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
 

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -9,6 +9,7 @@ use League\Flysystem\Exception;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Util;
 use LogicException;
+use SilverStripe\Assets\File;
 use SilverStripe\Assets\Storage\AssetNameGenerator;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\AssetStoreRouter;
@@ -19,6 +20,8 @@ use SilverStripe\Control\HTTPStreamResponse;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DB;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * Asset store based on flysystem Filesystem as a backend
@@ -80,6 +83,16 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @var int
      */
     private static $missing_response_code = 404;
+
+
+    /**
+     * Define the HTTP Response code for request that should be redirected to a different URL. Defaults to a temporary
+     * redirection (307). Set to 308 if you would rather your redirections be permanent and indicate to search engine
+     * that they should index the other file.
+     * @config
+     * @var int
+     */
+    private static $redirect_response_code = 307;
 
     /**
      * Custom headers to add to all custom file responses
@@ -770,9 +783,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param string $fileID
      * @return array
      */
-    protected function parseFileID($fileID)
+    protected function parseFileID($fileID, $forceLegacyName = false)
     {
-        if ($this->useLegacyFilenames()) {
+        if ($forceLegacyName || $this->useLegacyFilenames()) {
             $pattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
         } else {
             $pattern = '#^(?<folder>([^/]+/)*)(?<hash>[a-zA-Z0-9]{10})/(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
@@ -785,9 +798,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
         $variant = isset($matches['variant']) ? $matches['variant'] : null;
+        $hash = isset($matches['hash']) ? $matches['hash'] : null;
         return [
             'Filename' => $filename,
             'Variant' => $variant,
+            'Hash' => $hash
         ];
     }
 
@@ -913,24 +928,94 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     public function getResponseFor($asset)
     {
-        // Check if file exists
-        $filesystem = $this->getFilesystemFor($asset);
-        if (!$filesystem) {
-            return $this->createMissingResponse();
+
+        $public = $this->getPublicFilesystem();
+        $protected = $this->getProtectedFilesystem();
+
+        // If the file exists on the public store, we just straight return it.
+        if ($public->has($asset)) {
+            return $this->createResponseFor($public, $asset);
         }
 
-        // Block directory access
-        if ($filesystem->get($asset) instanceof Directory) {
-            return $this->createDeniedResponse();
+        // If the file exists in the protected store and the user has been explicitely granted access to it
+        if ($protected->has($asset) && $this->isGranted($asset)) {
+            return $this->createResponseFor($protected, $asset);
+            // Let's not deny if the file is in the protected store, but is not granted.
+            // We might be able to redirect to a live version.
+        }
+
+        // If we found a URL to redirect to
+        if ($redirectUrl = $this->searchForEquivalentFileID($asset)) {
+            if ($redirectUrl != $asset && $public->has($redirectUrl)) {
+                return $this->createRedirectResponse($redirectUrl);
+            } else {
+                // Something weird is going on e.g. a publish file without a physical file
+                return $this->createMissingResponse();
+            }
         }
 
         // Deny if file is protected and denied
-        if ($filesystem === $this->getProtectedFilesystem() && !$this->isGranted($asset)) {
+        if ($protected->has($asset)) {
             return $this->createDeniedResponse();
         }
 
-        // Serve up file response
-        return $this->createResponseFor($filesystem, $asset);
+        // We've looked everywhere and couldn't find a file
+        return $this->createMissingResponse();
+    }
+
+    /**
+     * @return string
+     */
+    private function searchForEquivalentFileID($asset)
+    {
+        // If File is not versionable, let's bail
+        if (!class_exists(Versioned::class) || !File::has_extension(Versioned::class)) {
+            return '';
+        }
+
+        $parsedFileID = $this->parseFileID($asset);
+        if ($parsedFileID && $parsedFileID['Hash']) {
+            // Try to find a live version of this file
+            $stage = Versioned::get_stage();
+            Versioned::set_stage(Versioned::LIVE);
+            $file = File::get()->filter(['FileFilename' => $parsedFileID['Filename']])->first();
+            Versioned::set_stage($stage);
+
+            // If we found a matching live file, let's see if our hash was publish at any point
+            if ($file) {
+                $oldVersionCount = $file->allVersions(
+                    [
+                        ['"FileHash" like ?' => DB::get_conn()->escapeString($parsedFileID['Hash']) . '%'],
+                        ['not "FileHash" like ?' => DB::get_conn()->escapeString($file->getHash())],
+                        'WasPublished' => true
+                    ],
+                    "",
+                    1
+                )->count();
+                // Our hash was published at some other stage
+                if ($oldVersionCount > 0) {
+                    return $this->getFileID($file->getFilename(), $file->getHash(), $parsedFileID['Variant']);
+                }
+            }
+        }
+
+        // Let's see if $asset is a legacy URL that can be map to a current file
+        $parsedFileID = $this->parseFileID($asset, true);
+        if ($parsedFileID) {
+            $filename = $parsedFileID['Filename'];
+            $variant = $parsedFileID['Variant'];
+            // Let's try to match the plain file name
+            $stage = Versioned::get_stage();
+            Versioned::set_stage(Versioned::LIVE);
+            $file = File::get()->filter(['FileFilename' => $filename])->first();
+            Versioned::set_stage($stage);
+
+            if ($file) {
+                return $this->getFileID($filename, $file->getHash(), $variant);
+            }
+        }
+
+        return '';
     }
 
     /**
@@ -941,6 +1026,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      */
     protected function createResponseFor(Filesystem $flysystem, $fileID)
     {
+        // Block directory access
+        if ($flysystem->get($fileID) instanceof Directory) {
+            return $this->createDeniedResponse();
+        }
+
         // Create streamable response
         $stream = $flysystem->readStream($fileID);
         $size = $flysystem->getSize($fileID);
@@ -953,6 +1043,22 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         foreach ($headers as $header => $value) {
             $response->addHeader($header, $value);
         }
+        return $response;
+    }
+
+    /**
+     * Redirect browser to specified file ID on the public store. Assumes an existence check for the fileID has
+     * already occured.
+     * @note This was introduced as a patch and will be rewritten/remove in SS4.4.
+     * @param $fileID
+     * @return HTTPResponse
+     */
+    private function createRedirectResponse($fileID)
+    {
+        $response = new HTTPResponse(null, $this->config()->get('redirect_response_code'));
+        /** @var PublicAdapter $adapter */
+        $adapter = $this->getPublicFilesystem()->getAdapter();
+        $response->addHeader('Location', $adapter->getPublicUrl($fileID));
         return $response;
     }
 

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -87,12 +87,12 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     /**
      * Define the HTTP Response code for request that should be redirected to a different URL. Defaults to a temporary
-     * redirection (307). Set to 308 if you would rather your redirections be permanent and indicate to search engine
+     * redirection (302). Set to 308 if you would rather your redirections be permanent and indicate to search engine
      * that they should index the other file.
      * @config
      * @var int
      */
-    private static $redirect_response_code = 307;
+    private static $redirect_response_code = 302;
 
     /**
      * Custom headers to add to all custom file responses
@@ -815,7 +815,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
     private function parseLegacyFileID($fileID)
     {
         // assets/folder/_resampled/ResizedImageWzEwMCwxMzNd/basename.extension
-        $ss3Pattern = '#^(?<folder>([^/_]+/)*?)(_resampled/(?<variant>([^/.]+))/)?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#';
+        $ss3Pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>([^/.]+))/)?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#';
         // assets/folder/basename__ResizedImageWzEwMCwxMzNd.extension
         $ss4LegacyPattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
 
@@ -990,6 +990,8 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
     }
 
     /**
+     * Given a FileID, try to find an equivalent file ID for a more recent file using the latest format.
+     * @param string $asset
      * @return string
      */
     private function searchForEquivalentFileID($asset)

--- a/tests/php/FileTest.yml
+++ b/tests/php/FileTest.yml
@@ -61,6 +61,9 @@ SilverStripe\Assets\Folder:
     Name: FileTest-restricted-view-folder
     CanViewType: OnlyTheseUsers
     ViewerGroups: =>SilverStripe\Security\Group.assetusers
+  deep-folder:
+    Name: super_deep_folder_with_underscores
+    ParentID: =>SilverStripe\Assets\Folder.folder1-subfolder1
 SilverStripe\Assets\File:
   asdf:
     FileFilename: FileTest.txt
@@ -95,6 +98,16 @@ SilverStripe\Assets\File:
     FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
     Name: File4.txt
     ParentID: =>SilverStripe\Assets\Folder.restrictedViewFolder
+  double-extension:
+    FileFilename: FileTest-folder1/FileTest-folder1-subfolder1/super_deep_folder_with_underscores/Archive.tar.gz
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: Archive.tar.gz
+    ParentID: =>SilverStripe\Assets\Folder.deep-folder
+  double-underscore:
+    FileFilename: FileTest-folder1/FileTest-folder1-subfolder1/super_deep_folder_with_underscores/file_with_underscores.tar.gz
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: file_with_underscores.gz
+    ParentID: =>SilverStripe\Assets\Folder.deep-folder
 
 SilverStripe\Assets\Image:
   gif:

--- a/tests/php/ProtectedFileControllerTest.php
+++ b/tests/php/ProtectedFileControllerTest.php
@@ -52,6 +52,12 @@ class ProtectedFileControllerTest extends FunctionalTest
         }
     }
 
+    public function tearDown()
+    {
+        TestAssetStore::reset();
+        parent::tearDown();
+    }
+
     /**
      * @dataProvider getFilenames
      */

--- a/tests/php/RedirectFileControllerTest.php
+++ b/tests/php/RedirectFileControllerTest.php
@@ -150,15 +150,9 @@ class RedirectFileControllerTest extends FunctionalTest
 
         $response = $this->get($v1Url);
 
-        if (File::config()->get('keep_archived_assets')) {
-            // This only runs on RedirectKeepArchiveFileControllerTest
-            $this->assertResponse(403, '', false, $response,
-                'Old Hash URL of unpublsihed files should return 403');
-        } else {
-            $this->assertResponse(404, '', false, $response,
-                'Old Hash URL of unpublsihed files should return 404');
-        }
 
+        $this->assertResponse(404, '', false, $response,
+            'Old Hash URL of unpublsihed files should return 404');
     }
 
     public function testRedirectAfterDeleting() {

--- a/tests/php/RedirectFileControllerTest.php
+++ b/tests/php/RedirectFileControllerTest.php
@@ -61,24 +61,41 @@ class RedirectFileControllerTest extends FunctionalTest
         parent::tearDown();
     }
 
-    public function testLegacyFilenameRedirect() {
+    public function testLegacyFilenameRedirect()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
 
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(404, '', false, $response,
-            'Legacy URL for unpublished file should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Legacy URL for unpublished file should return 404'
+        );
 
         $file->publishSingle();
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(307, '', $file->getURL(false), $response,
-            'Legacy URL for published file should return 307');
+        $this->assertResponse(
+            307,
+            '',
+            $file->getURL(false),
+            $response,
+            'Legacy URL for published file should return 307'
+        );
 
         $response = $this->get($response->getHeader('location'));
-        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
-            'Redirected legacy url should return 200');
+        $this->assertResponse(
+            200,
+            str_repeat('x', 1000000),
+            false,
+            $response,
+            'Redirected legacy url should return 200'
+        );
     }
 
-    public function testRedirectWithDraftFile() {
+    public function testRedirectWithDraftFile()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
         $file->publishSingle();
         $v1Url = $file->getURL(false);
@@ -89,19 +106,35 @@ class RedirectFileControllerTest extends FunctionalTest
 
         // Before publishing second draft file
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(307, '', $v1Url, $response,
-            'Legacy URL for published file should return 307 to live file');
+        $this->assertResponse(
+            307,
+            '',
+            $v1Url,
+            $response,
+            'Legacy URL for published file should return 307 to live file'
+        );
 
         $response = $this->get($response->getHeader('location'));
-        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
-            'Redirected legacy url should return 200 with content of live file');
+        $this->assertResponse(
+            200,
+            str_repeat('x', 1000000),
+            false,
+            $response,
+            'Redirected legacy url should return 200 with content of live file'
+        );
 
         $response = $this->get($v2Url);
-        $this->assertResponse(403, '', false, $response,
-            'Draft URL without grant should 403');
+        $this->assertResponse(
+            403,
+            '',
+            false,
+            $response,
+            'Draft URL without grant should 403'
+        );
     }
 
-    public function testRedirectAfterPublishSecondVersion() {
+    public function testRedirectAfterPublishSecondVersion()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
         $file->publishSingle();
         $v1Url = $file->getURL(false);
@@ -114,20 +147,35 @@ class RedirectFileControllerTest extends FunctionalTest
 
         // After publishing second draft file
         $response = $this->get($v2Url);
-        $this->assertResponse(200, 'version 2', false, $response,
-            'Publish version should resolve with 200');
+        $this->assertResponse(
+            200,
+            'version 2',
+            false,
+            $response,
+            'Publish version should resolve with 200'
+        );
 
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(307, '', $v2Url, $response,
-            'Legacy URL should redirect to the latest live version');
+        $this->assertResponse(
+            307,
+            '',
+            $v2Url,
+            $response,
+            'Legacy URL should redirect to the latest live version'
+        );
 
         $response = $this->get($v1Url);
-        $this->assertResponse(307, '', $v2Url, $response,
-            'Old Hash URL should redirect to the latest live version');
-
+        $this->assertResponse(
+            307,
+            '',
+            $v2Url,
+            $response,
+            'Old Hash URL should redirect to the latest live version'
+        );
     }
 
-    public function testRedirectAfterUnpublish() {
+    public function testRedirectAfterUnpublish()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
         $file->publishSingle();
         $v1Url = $file->getURL(false);
@@ -141,21 +189,37 @@ class RedirectFileControllerTest extends FunctionalTest
 
         // After unpublishing file
         $response = $this->get($v2Url);
-        $this->assertResponse(403, '', false, $response,
-            'Unpublish file should return 403');
+        $this->assertResponse(
+            403,
+            '',
+            false,
+            $response,
+            'Unpublish file should return 403'
+        );
 
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(404, '', false, $response,
-            'Legacy URL of unpublish files should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Legacy URL of unpublish files should return 404'
+        );
 
         $response = $this->get($v1Url);
 
 
-        $this->assertResponse(404, '', false, $response,
-            'Old Hash URL of unpublsihed files should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Old Hash URL of unpublsihed files should return 404'
+        );
     }
 
-    public function testRedirectAfterDeleting() {
+    public function testRedirectAfterDeleting()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
         $file->publishSingle();
         $v1Url = $file->getURL(false);
@@ -169,16 +233,31 @@ class RedirectFileControllerTest extends FunctionalTest
         $file->deleteFile();
 
         $response = $this->get($v2Url);
-        $this->assertResponse(404, '', false, $response,
-            'Deleted file file should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Deleted file file should return 404'
+        );
 
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(404, '', false, $response,
-            'Legacy URL of deleted files should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Legacy URL of deleted files should return 404'
+        );
 
         $response = $this->get($v1Url);
-        $this->assertResponse(404, '', false, $response,
-            'Old Hash URL of deleted files should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Old Hash URL of deleted files should return 404'
+        );
     }
 
     public function testVariantRedirect()
@@ -195,12 +274,31 @@ class RedirectFileControllerTest extends FunctionalTest
         $suffix = $ico->getVariant();
 
         $response = $this->get($icoUrl);
-        $this->assertResponse(200, $ico->getString(), false, $response,
-            'Publish variant sghould resolve with 200');
+        $this->assertResponse(
+            200,
+            $ico->getString(),
+            false,
+            $response,
+            'Publish variant sghould resolve with 200'
+        );
 
-        $response = $this->get("assets/test__$suffix.jpg");
-        $this->assertResponse(307, '', $icoUrl, $response,
-            'Legacy path to variant should resolve.');
+        $response = $this->get("/assets/test__$suffix.jpg");
+        $this->assertResponse(
+            307,
+            '',
+            $icoUrl,
+            $response,
+            'Legacy path to variant should redirect.'
+        );
+
+        $response = $this->get("/assets/_resampled/$suffix/test.jpg");
+        $this->assertResponse(
+            307,
+            '',
+            $icoUrl,
+            $response,
+            'SS3 Legacy path to variant should redirect.'
+        );
 
         $file->setFromLocalFile(__DIR__ . '/ImageTest/test-image-high-quality.jpg', 'test.jpg');
         $file->write();
@@ -209,9 +307,74 @@ class RedirectFileControllerTest extends FunctionalTest
         $icoV2Url = $ico->getURL(false);
 
         $response = $this->get($icoUrl);
-        $this->assertResponse(307, '', $icoV2Url, $response,
-            'Old URL to variant should redirect with 307');
+        $this->assertResponse(
+            307,
+            '',
+            $icoV2Url,
+            $response,
+            'Old URL to variant should redirect with 307'
+        );
+    }
 
+    public function testVariantInFolderRedirect()
+    {
+        /** @var Folder $folder */
+        $folder = Folder::create();
+        $folder->Filename = 'SubFolderOfDoom';
+        $folder->write();
+
+        /** @var Image $file */
+        $file = Image::create();
+        $file->ParentID = $folder->ID;
+        $file->FileFilename = 'SubFolderOfDoom/test.jpg';
+        $file->setFromLocalFile(__DIR__ . '/ImageTest/landscape-to-portrait.jpg', 'SubFolderOfDoom/test.jpg');
+        $file->write();
+        $file->publishSingle();
+        $ico = $file->ScaleWidth(32);
+        $icoUrl = $ico->getURL(false);
+        $suffix = $ico->getVariant();
+
+        $response = $this->get($icoUrl);
+        $this->assertResponse(
+            200,
+            $ico->getString(),
+            false,
+            $response,
+            'Publish variant sghould resolve with 200'
+        );
+
+        $response = $this->get("/assets/SubFolderOfDoom/test__$suffix.jpg");
+        $this->assertResponse(
+            307,
+            '',
+            $icoUrl,
+            $response,
+            'Legacy path to variant should redirect.'
+        );
+
+        $response = $this->get("/assets/SubFolderOfDoom/_resampled/$suffix/test.jpg");
+        $this->assertResponse(
+            307,
+            '',
+            $icoUrl,
+            $response,
+            'SS3 Legacy path to variant should redirect.'
+        );
+
+        $file->setFromLocalFile(__DIR__ . '/ImageTest/test-image-high-quality.jpg', 'SubFolderOfDoom/test.jpg');
+        $file->write();
+        $file->publishSingle();
+        $ico = $file->ScaleWidth(32);
+        $icoV2Url = $ico->getURL(false);
+
+        $response = $this->get($icoUrl);
+        $this->assertResponse(
+            307,
+            '',
+            $icoV2Url,
+            $response,
+            'Old URL to variant should redirect with 307'
+        );
     }
 
     public function testDraftOnlyArchivedVersion()
@@ -226,9 +389,13 @@ class RedirectFileControllerTest extends FunctionalTest
         $v2Url = $file->getURL(false);
 
         $response = $this->get($v1Url);
-        $this->assertResponse(404, '', false, $response,
-            'Old Hash URL of version that never got published should return 404');
-
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Old Hash URL of version that never got published should return 404'
+        );
     }
 
     /**

--- a/tests/php/RedirectFileControllerTest.php
+++ b/tests/php/RedirectFileControllerTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace SilverStripe\Assets\Tests;
+
+use SilverStripe\Assets\Image;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Assets\Storage\ProtectedFileController;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Filesystem;
+use SilverStripe\Assets\File;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Assets\Tests\Storage\AssetStoreTest\TestAssetStore;
+
+/**
+ * @skipUpgrade
+ */
+class RedirectFileControllerTest extends FunctionalTest
+{
+    protected static $fixture_file = 'FileTest.yml';
+
+    protected $autoFollowRedirection = false;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Set backend root to /ImageTest
+        TestAssetStore::activate('RedirectFileControllerTest');
+
+        // Create a test folders for each of the fixture references
+        foreach (Folder::get() as $folder) {
+            /** @var Folder $folder */
+            $filePath = TestAssetStore::getLocalPath($folder);
+            Filesystem::makeFolder($filePath);
+        }
+
+        // Create a test files for each of the fixture references
+        foreach (File::get()->exclude('ClassName', Folder::class) as $file) {
+            /** @var File $file */
+            $path = TestAssetStore::getLocalPath($file);
+            Filesystem::makeFolder(dirname($path));
+            $fh = fopen($path, "w+");
+            fwrite($fh, str_repeat('x', 1000000));
+            fclose($fh);
+
+            // Create variant for each file
+            $this->getAssetStore()->setFromString(
+                str_repeat('y', 100),
+                $file->Filename,
+                $file->Hash,
+                'variant'
+            );
+        }
+    }
+
+    public function tearDown()
+    {
+        TestAssetStore::reset();
+        parent::tearDown();
+    }
+
+    public function testLegacyFilenameRedirect() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(404, '', false, $response,
+            'Legacy URL for unpublished file should return 404');
+
+        $file->publishSingle();
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(307, '', $file->getURL(false), $response,
+            'Legacy URL for published file should return 307');
+
+        $response = $this->get($response->getHeader('location'));
+        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
+            'Redirected legacy url should return 200');
+    }
+
+    public function testRedirectWithDraftFile() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $file->publishSingle();
+        $v1Url = $file->getURL(false);
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $v2Url = $file->getURL(false);
+
+        // Before publishing second draft file
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(307, '', $v1Url, $response,
+            'Legacy URL for published file should return 307 to live file');
+
+        $response = $this->get($response->getHeader('location'));
+        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
+            'Redirected legacy url should return 200 with content of live file');
+
+        $response = $this->get($v2Url);
+        $this->assertResponse(403, '', false, $response,
+            'Draft URL without grant should 403');
+    }
+
+    public function testRedirectAfterPublishSecondVersion() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $file->publishSingle();
+        $v1Url = $file->getURL(false);
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $v2Url = $file->getURL(false);
+
+        $file->publishSingle();
+
+        // After publishing second draft file
+        $response = $this->get($v2Url);
+        $this->assertResponse(200, 'version 2', false, $response,
+            'Publish version should resolve with 200');
+
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(307, '', $v2Url, $response,
+            'Legacy URL should redirect to the latest live version');
+
+        $response = $this->get($v1Url);
+        $this->assertResponse(307, '', $v2Url, $response,
+            'Old Hash URL should redirect to the latest live version');
+
+    }
+
+    public function testRedirectAfterUnpublish() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $file->publishSingle();
+        $v1Url = $file->getURL(false);
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $v2Url = $file->getURL(false);
+
+        $file->publishSingle();
+        $file->doUnpublish();
+
+        // After unpublishing file
+        $response = $this->get($v2Url);
+        $this->assertResponse(403, '', false, $response,
+            'Unpublish file should return 403');
+
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(404, '', false, $response,
+            'Legacy URL of unpublish files should return 404');
+
+        $response = $this->get($v1Url);
+
+        if (File::config()->get('keep_archived_assets')) {
+            // This only runs on RedirectKeepArchiveFileControllerTest
+            $this->assertResponse(403, '', false, $response,
+                'Old Hash URL of unpublsihed files should return 403');
+        } else {
+            $this->assertResponse(404, '', false, $response,
+                'Old Hash URL of unpublsihed files should return 404');
+        }
+
+    }
+
+    public function testRedirectAfterDeleting() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $file->publishSingle();
+        $v1Url = $file->getURL(false);
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $file->publishSingle();
+        $v2Url = $file->getURL(false);
+
+        $file->delete();
+        $file->deleteFile();
+
+        $response = $this->get($v2Url);
+        $this->assertResponse(404, '', false, $response,
+            'Deleted file file should return 404');
+
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(404, '', false, $response,
+            'Legacy URL of deleted files should return 404');
+
+        $response = $this->get($v1Url);
+        $this->assertResponse(404, '', false, $response,
+            'Old Hash URL of deleted files should return 404');
+    }
+
+    public function testVariantRedirect()
+    {
+        /** @var Image $file */
+        $file = Image::create();
+
+        $file->FileFilename = 'test.jpg';
+        $file->setFromLocalFile(__DIR__ . '/ImageTest/landscape-to-portrait.jpg', 'test.jpg');
+        $file->write();
+        $file->publishSingle();
+        $ico = $file->ScaleWidth(32);
+        $icoUrl = $ico->getURL(false);
+        $suffix = $ico->getVariant();
+
+        $response = $this->get($icoUrl);
+        $this->assertResponse(200, $ico->getString(), false, $response,
+            'Publish variant sghould resolve with 200');
+
+        $response = $this->get("assets/test__$suffix.jpg");
+        $this->assertResponse(307, '', $icoUrl, $response,
+            'Legacy path to variant should resolve.');
+
+        $file->setFromLocalFile(__DIR__ . '/ImageTest/test-image-high-quality.jpg', 'test.jpg');
+        $file->write();
+        $file->publishSingle();
+        $ico = $file->ScaleWidth(32);
+        $icoV2Url = $ico->getURL(false);
+
+        $response = $this->get($icoUrl);
+        $this->assertResponse(307, '', $icoV2Url, $response,
+            'Old URL to variant should redirect with 307');
+
+    }
+
+    public function testDraftOnlyArchivedVersion()
+    {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $v1Url = $file->getURL(false);
+        $file->deleteFile();
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $file->publishSingle();
+        $v2Url = $file->getURL(false);
+
+        $response = $this->get($v1Url);
+        $this->assertResponse(404, '', false, $response,
+            'Old Hash URL of version that never got published should return 404');
+
+    }
+
+    /**
+     * @return AssetStore
+     */
+    protected function getAssetStore()
+    {
+        return Injector::inst()->get(AssetStore::class);
+    }
+
+    /**
+     * Assert that a response matches the given parameters
+     *
+     * @param int          $code        HTTP code
+     * @param string       $body        Body expected for 200 responses
+     * @param string|false $location    Location to redirect to or false if no redirect
+     * @param HTTPResponse $response
+     * @param string       $message
+     */
+    protected function assertResponse($code, $body, $location, HTTPResponse $response, $message = '')
+    {
+        $this->assertEquals($code, $response->getStatusCode(), $message);
+        if ($code < 400) {
+            $this->assertFalse($response->isError(), $message);
+            $this->assertEquals($body, $response->getBody(), $message);
+        } else {
+            $this->assertTrue($response->isError(), $message);
+        }
+
+        if ($location) {
+            $this->assertEquals(
+                $this->normaliseUrl($location),
+                $this->normaliseUrl($response->getHeader('location')),
+                $message
+            );
+        } else {
+            $this->assertNull($response->getHeader('location'), $message);
+        }
+    }
+
+    /**
+     * When the CMS builds a URL it wants to include our test folder in it. We want to strip that out.
+     * @param $path
+     * @return mixed
+     */
+    protected function normaliseUrl($path)
+    {
+        return str_replace('RedirectFileControllerTest/', '', $path);
+    }
+
+    public function get($url, $session = null, $headers = null, $cookies = null)
+    {
+        return parent::get($this->normaliseUrl($url), $session, $headers, $cookies);
+    }
+}

--- a/tests/php/RedirectKeepArchiveFileControllerTest.php
+++ b/tests/php/RedirectKeepArchiveFileControllerTest.php
@@ -26,7 +26,8 @@ class RedirectKeepArchiveFileControllerTest extends RedirectFileControllerTest
         parent::setUp();
     }
 
-    public function testRedirectAfterUnpublish() {
+    public function testRedirectAfterUnpublish()
+    {
         $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
         $file->publishSingle();
         $v1hash = $file->getHash();
@@ -41,28 +42,52 @@ class RedirectKeepArchiveFileControllerTest extends RedirectFileControllerTest
         $this->getAssetStore()->grant('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
         $response = $this->get($v1Url);
         $this->getAssetStore()->revoke('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
-        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
-            'Old Hash URL of live file should return 200 when access is granted');
+        $this->assertResponse(
+            200,
+            str_repeat('x', 1000000),
+            false,
+            $response,
+            'Old Hash URL of live file should return 200 when access is granted'
+        );
 
         $file->doUnpublish();
 
         // After unpublishing file
         $response = $this->get($v2Url);
-        $this->assertResponse(403, '', false, $response,
-            'Unpublish file should return 403');
+        $this->assertResponse(
+            403,
+            '',
+            false,
+            $response,
+            'Unpublish file should return 403'
+        );
 
         $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
-        $this->assertResponse(404, '', false, $response,
-            'Legacy URL of unpublish files should return 404');
+        $this->assertResponse(
+            404,
+            '',
+            false,
+            $response,
+            'Legacy URL of unpublish files should return 404'
+        );
 
         $response = $this->get($v1Url);
-        $this->assertResponse(403, '', false, $response,
-            'Old Hash URL of unpublished files should return 403');
+        $this->assertResponse(
+            403,
+            '',
+            false,
+            $response,
+            'Old Hash URL of unpublished files should return 403'
+        );
 
         $this->getAssetStore()->grant('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
         $response = $this->get($v1Url);
-        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
-            'Old Hash URL of unpublished files should return 200 when access is granted');
-
+        $this->assertResponse(
+            200,
+            str_repeat('x', 1000000),
+            false,
+            $response,
+            'Old Hash URL of unpublished files should return 200 when access is granted'
+        );
     }
 }

--- a/tests/php/RedirectKeepArchiveFileControllerTest.php
+++ b/tests/php/RedirectKeepArchiveFileControllerTest.php
@@ -25,4 +25,44 @@ class RedirectKeepArchiveFileControllerTest extends RedirectFileControllerTest
         File::config()->set('keep_archived_assets', true);
         parent::setUp();
     }
+
+    public function testRedirectAfterUnpublish() {
+        $file = File::find('FileTest-subfolder/FileTestSubfolder.txt');
+        $file->publishSingle();
+        $v1hash = $file->getHash();
+        $v1Url = $file->getURL(false);
+
+        $file->setFromString('version 2', $file->getFilename());
+        $file->write();
+        $v2Url = $file->getURL(false);
+
+        $file->publishSingle();
+
+        $this->getAssetStore()->grant('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
+        $response = $this->get($v1Url);
+        $this->getAssetStore()->revoke('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
+        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
+            'Old Hash URL of live file should return 200 when access is granted');
+
+        $file->doUnpublish();
+
+        // After unpublishing file
+        $response = $this->get($v2Url);
+        $this->assertResponse(403, '', false, $response,
+            'Unpublish file should return 403');
+
+        $response = $this->get('/assets/FileTest-subfolder/FileTestSubfolder.txt');
+        $this->assertResponse(404, '', false, $response,
+            'Legacy URL of unpublish files should return 404');
+
+        $response = $this->get($v1Url);
+        $this->assertResponse(403, '', false, $response,
+            'Old Hash URL of unpublished files should return 403');
+
+        $this->getAssetStore()->grant('FileTest-subfolder/FileTestSubfolder.txt', $v1hash);
+        $response = $this->get($v1Url);
+        $this->assertResponse(200, str_repeat('x', 1000000), false, $response,
+            'Old Hash URL of unpublished files should return 200 when access is granted');
+
+    }
 }

--- a/tests/php/RedirectKeepArchiveFileControllerTest.php
+++ b/tests/php/RedirectKeepArchiveFileControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\Assets\Tests;
+
+use SilverStripe\Assets\Image;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Assets\Storage\ProtectedFileController;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Filesystem;
+use SilverStripe\Assets\File;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Assets\Tests\Storage\AssetStoreTest\TestAssetStore;
+
+/**
+ * We rerun all the same test in `RedirectFileControllerTest` but with keep_archived_assets on
+ * @skipUpgrade
+ */
+class RedirectKeepArchiveFileControllerTest extends RedirectFileControllerTest
+{
+
+    public function setUp()
+    {
+        File::config()->set('keep_archived_assets', true);
+        parent::setUp();
+    }
+}

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -278,7 +278,7 @@ class AssetStoreTest extends SapphireTest
                 'directory/2a17a9cb4b/file.jpg',
                 [
                     'Filename' => 'directory/file.jpg',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => null
                 ],
             ],
@@ -286,7 +286,7 @@ class AssetStoreTest extends SapphireTest
                 '2a17a9cb4b/file.jpg',
                 [
                     'Filename' => 'file.jpg',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => null
                 ],
             ],
@@ -294,7 +294,7 @@ class AssetStoreTest extends SapphireTest
                 'dir_ectory/2a17a9cb4b/file_e.jpg',
                 [
                     'Filename' => 'dir_ectory/file_e.jpg',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => null
                 ],
             ],
@@ -302,7 +302,7 @@ class AssetStoreTest extends SapphireTest
                 'directory/2a17a9cb4b/file__variant.jpg',
                 [
                     'Filename' => 'directory/file.jpg',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => 'variant'
                 ],
             ],
@@ -310,7 +310,7 @@ class AssetStoreTest extends SapphireTest
                 '2a17a9cb4b/file__var__iant.jpg',
                 [
                     'Filename' => 'file.jpg',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => 'var__iant'
                 ],
             ],
@@ -318,7 +318,7 @@ class AssetStoreTest extends SapphireTest
                 '2a17a9cb4b/file__var__iant',
                 [
                     'Filename' => 'file',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => 'var__iant'
                 ],
             ],
@@ -326,7 +326,7 @@ class AssetStoreTest extends SapphireTest
                 '2a17a9cb4b/file',
                 [
                     'Filename' => 'file',
-                    'Hash' => sha1('puppies'),
+                    'Hash' => substr(sha1('puppies'), 0, 10),
                     'Variant' => null
                 ],
             ]
@@ -395,7 +395,7 @@ class AssetStoreTest extends SapphireTest
         } else {
             $this->assertEquals($tuple['Filename'], $result['Filename']);
             $this->assertEquals($tuple['Variant'], $result['Variant']);
-            $this->assertArrayNotHasKey('Hash', $result);
+            $this->assertEquals($tuple['Hash'], $result['Hash']);
         }
     }
 

--- a/tests/php/Storage/AssetStoreTest/TestAssetStore.php
+++ b/tests/php/Storage/AssetStoreTest/TestAssetStore.php
@@ -162,9 +162,9 @@ class TestAssetStore extends FlysystemAssetStore
         return parent::getFileID($filename, $hash, $variant);
     }
 
-    public function parseFileID($fileID)
+    public function parseFileID($fileID, $forceLegacy = false)
     {
-        return parent::parseFileID($fileID);
+        return parent::parseFileID($fileID, $forceLegacy);
     }
 
     public function getOriginalFilename($fileID)

--- a/tests/php/Storage/AssetStoreTest/TestAssetStore.php
+++ b/tests/php/Storage/AssetStoreTest/TestAssetStore.php
@@ -130,8 +130,9 @@ class TestAssetStore extends FlysystemAssetStore
      * @param  AssetContainer $asset
      * @return string
      */
-    public static function getLocalPath(AssetContainer $asset)
+    public static function getLocalPath(AssetContainer $asset, $forceProtected = false)
     {
+
         if ($asset instanceof Folder) {
             return self::base_path() . '/' . $asset->getFilename();
         }
@@ -144,7 +145,7 @@ class TestAssetStore extends FlysystemAssetStore
         $fileID = $assetStore->getFileID($asset->Filename, $asset->Hash, $asset->Variant);
         /** @var Filesystem $filesystem */
         $filesystem = $assetStore->getProtectedFilesystem();
-        if (!$filesystem->has($fileID)) {
+        if (!$forceProtected && !$filesystem->has($fileID)) {
             $filesystem = $assetStore->getPublicFilesystem();
         }
         /** @var Local $adapter */


### PR DESCRIPTION
This PR rewrites the `FlysystemAssetStore::getResponseFor()` method so that SS3 style url and the hash-url of old publish URL can get redirected to the latest live version. This works for SS4 variants as well.

# Limitations
* Hash URL don't get redirected when using `legacy_filenames`.
* Redirects do not work when the Filename is change in the CMS or when a file is moved to a different folder.

# Parent issue
* https://github.com/silverstripe/silverstripe-versioned/issues/177