### PR TITLE
Option to retain the `LastEdited` dates of migrated Files

### DIFF
--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -73,12 +73,6 @@ class FileMigrationHelper
             Versioned::set_stage(Versioned::DRAFT);
         }
 
-        // Save and publish
-        $newFile->write();
-        if (class_exists(Versioned::class)) {
-            $newFile->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
-        }
-
         foreach ($this->getFileQuery() as $file) {
             // Bypass the accessor and the filename from the column
             $filename = $file->getField('Filename');

--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -170,12 +170,14 @@ class FileMigrationHelper
         // if 'LastEdited' date static is enabled, update file's last edited using SQL query
         if ($this->config()->get('keep_lastedited_date') && $lastEditedDate) {
             // Draft table
-            $update = SQLUpdate::create('File')->addWhere(['ID' => $file->ID]);
+            $table = DataObject::singleton(File::class)->baseTable();
+            $update = SQLUpdate::create($table)->addWhere(['ID' => $file->ID]);
             $update->assign('LastEdited', $lastEditedDate);
             $update->execute();
 
             // Live table
-            $update = SQLUpdate::create('File_Live')->addWhere(['ID' => $file->ID]);
+            $table = DataObject::singleton(File::class)->stageTable($table, Versioned::LIVE);
+            $update = SQLUpdate::create($table)->addWhere(['ID' => $file->ID]);
             $update->assign('LastEdited', $lastEditedDate);
             $update->execute();
         }


### PR DESCRIPTION
The current SilverStripe file migration task automatically updates the `LastEdited` date of a migrated file which causes problems when users are attempting to generate particular reports which are reliant on the original state of the `LastEdited` date of a file. 

This PR adds a new option/static to SilverStripe's file migration task from 3.x to 4.x where dev's can set the `keep_lastedited_date` static to retain the original state of the `LastEdited` date of all migrated files.

# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/222