### PR TITLE
POC: Re-encoding images as different filetypes

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -100,6 +100,14 @@ class InterventionBackend implements Image_Backend, Flushable
     }
 
     /**
+     * @return bool
+     */
+    public function supportsReencoding()
+    {
+        return true;
+    }
+
+    /**
      * @return string The temporary local path for this image
      */
     public function getTempPath()


### PR DESCRIPTION
This is a quick and dumb proof of concept for the following:

```php
// assets/Uploads/some-file.jpg
{$Image.URL}

// assets/Uploads/some-file__EncodeAsWyJwbmciXQ.png
{$Image.EncodeAs('png').URL}

// assets/Uploads/some-file__EncodeAsWyJ3ZWJwIl0.webp
{$Image.EncodeAs('webp').URL}
```

It takes advantage of the fact that `intervention/image` will automatically encode it in the appropriate based on filename. If the format provided isn’t supported by the current driver, `InterventionBackend::writeToStore()` currently silently swallows the `NotSupportedException`.

If this would be a welcome addition, I’m open to ideas for the best approach/API design for this. Other `Image_Backend`s (I’m not actually aware of any in the wild?) may not be able to do this, so we can’t assume it’s always possible. Because of that, and the fact that we can’t add anything to the `Image_Backend` interface outside of a major release, this would probably have to rely on `method_exist()` calls.