### PR TITLE
More verbose file migration logging

### DIFF
--- a/_config/migration.yml
+++ b/_config/migration.yml
@@ -1,0 +1,11 @@
+---
+Name: file-migration
+---
+# Remove the HTTPOutputHandler from the logger on the file migration.
+# It logs a lot of >= NOTICE errors that pollute the output with backtrace.
+SilverStripe\Core\Injector\Injector:
+  Psr\Log\LoggerInterface.quiet:
+    type: singleton
+    class: Monolog\Logger
+    constructor:
+      - "file-migration"

--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -49,10 +49,13 @@ class FileMigrationHelper extends BaseFileMigrationHelper
 
     /**
      * @param LoggerInterface $logger
+     * @return $this
      */
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+
+        return $this;
     }
 
     /**

--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -40,14 +40,6 @@ class FileMigrationHelper extends BaseFileMigrationHelper
      */
     private static $delete_invalid_files = true;
 
-    /**
-     * Specifies the interval for every Nth file looped at which output will be logged.
-     *
-     * @config
-     * @var int
-     */
-    private static $log_interval = 10;
-
     private static $dependencies = [
         'logger' => '%$' . LoggerInterface::class,
     ];
@@ -80,6 +72,7 @@ class FileMigrationHelper extends BaseFileMigrationHelper
         // If not, cannot migrate
         /** @skipUpgrade */
         if (!DB::get_schema()->hasField('File', 'Filename')) {
+            $this->logger->error('Database not ready for migration. Please run dev/build');
             return 0;
         }
 
@@ -96,26 +89,39 @@ class FileMigrationHelper extends BaseFileMigrationHelper
         }
 
         $query = $this->getFileQuery();
-        $total = $query->count();
+        $totalCount = $query->count();
+
+        if (!$totalCount) {
+            return 0;
+        }
+
+        $this->logger->info(sprintf('Migrating %d files', $totalCount));
+
         foreach ($query as $file) {
             // Bypass the accessor and the filename from the column
             $filename = $file->getField('Filename');
-            $success = $this->migrateFile($base, $file, $filename);
 
-            if ($processedCount % $this->config()->get('log_interval') === 0) {
-                if ($this->logger) {
-                    $this->logger->info("Iterated $processedCount out of $total files. Migrated $migratedCount files.");
-                }
-            }
+            $this->logger->info(sprintf('Migrating %s', $filename));
+
+            $success = $this->migrateFile($base, $file, $filename);
 
             $processedCount++;
             if ($success) {
                 $migratedCount++;
             }
         }
+
         if (class_exists(Versioned::class)) {
             Versioned::set_reading_mode($originalState);
         }
+
+        if ($processedCount < $totalCount) {
+            $this->logger->warning(sprintf(
+                'Failed to migrate %d files, please review errors',
+                $totalCount - $processedCount
+            ));
+        }
+
         return $migratedCount;
     }
 
@@ -179,7 +185,7 @@ class FileMigrationHelper extends BaseFileMigrationHelper
             }
             $file = File::get_by_id($fileID);
         }
-        
+
         if (!is_readable($path)) {
             if ($this->logger) {
                 $this->logger->warning(sprintf(
@@ -239,6 +245,8 @@ class FileMigrationHelper extends BaseFileMigrationHelper
             }
             return $removed;
         }
+
+        return true;
     }
 
     /**

--- a/src/FileMigrationHelper.php
+++ b/src/FileMigrationHelper.php
@@ -44,7 +44,9 @@ class FileMigrationHelper extends BaseFileMigrationHelper
         'logger' => '%$' . LoggerInterface::class . '.quiet',
     ];
 
-    /** @var LoggerInterface|null */
+    /**
+     * @var LoggerInterface|null
+     */
     private $logger;
 
     /**


### PR DESCRIPTION
The log interval was useful to see errors in the noise,
but it's also masked what the task actually does.
Since this is moving and modifying project data,
it should be verbose by default. This will help answer
question later on, e.g. "why wasn't this file migrated".

A new message at the bottom which spells out how many files failed (if any)
makes it clear that you need to review the logs in detail (even though the error lines might hide between a lot of success lines).