### PR TITLE
NEW Clean up secureassets module artefacts (fixes #231)

### DIFF
--- a/src/Dev/Tasks/SecureAssetsMigrationHelper.php
+++ b/src/Dev/Tasks/SecureAssetsMigrationHelper.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace SilverStripe\Assets\Dev\Tasks;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use League\Flysystem\Filesystem;
+use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+/**
+ * Removes stray .htaccess files created through the silverstripe/secureassets module
+ * on a 3.x-based site. The 4.x protections work differently:
+ * One central assets/.htaccess file routes non-existent paths through SilverStripe,
+ * which can choose to return a file from assets/.protected.
+ * Any additional .htaccess files in folders can interfere with this logic.
+ *
+ * Note that this task does not migrate file metadata added/managed through silverstripe/secureassets.
+ * The metadata fields are the same in 4.x (File.CanViewType etc).
+ *
+ * See https://github.com/silverstripe/silverstripe-assets/issues/231
+ *
+ * @internal
+ */
+class SecureAssetsMigrationHelper
+{
+    use Injectable;
+    use Configurable;
+
+    /**
+     * @var array
+     */
+    protected $htaccessRegexes = [];
+
+    private static $dependencies = [
+        'logger' => '%$' . LoggerInterface::class,
+    ];
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct()
+    {
+        $this->logger = new NullLogger();
+
+        $this->htaccessRegexes = [
+            '#RewriteEngine On#',
+            '#RewriteBase .*#', // allow any base folder
+            '#' . preg_quote('RewriteCond %{REQUEST_URI} ^(.*)$') . '#',
+            '#RewriteRule .*' . preg_quote('main.php?url=%1 [QSA]') . '#' // allow any framework base path
+        ];
+    }
+
+    /**
+     * Perform migration
+     *
+     * @param FlysystemAssetStore $store
+     * @return array Folders which needed migration
+     */
+    public function run(FlysystemAssetStore $store)
+    {
+        $migrated = [];
+
+        // There's no way .htaccess files could've been created by silverstripe/secureassets
+        // in a protected filesystem (didn't exist in 3.x)
+        $filesystem = $store->getPublicFilesystem();
+
+        // The presence of secured folders can either come
+        // from a freshly migrated 3.x database with silverstripe/secureassets,
+        // or from an already used 4.x database with built-in asset protections.
+        // Because the module itself has been removed in 4.x installs,
+        // we can no longer tell the difference between those cases.
+        $securedFolders = SQLSelect::create()
+            ->setFrom('File')
+            ->setSelect([
+                '"ID"',
+                '"FileFilename"',
+            ])
+            ->addWhere([
+                '"ClassName" = ?' => 'SilverStripe\Assets\Folder',
+                // We don't need to check 'Inherited' permissions,
+                // since Apache applies parent .htaccess and the module doesn't create them in this case.
+                // See SecureFileExtension->needsAccessFile()
+                '"CanViewType" IN(?,?)' => ['LoggedInUsers', 'OnlyTheseUsers']
+            ]);
+
+        if (!$securedFolders->count()) {
+            $this->logger->info('No need for secure files migration');
+            return [];
+        }
+
+        foreach ($securedFolders->execute()->map() as $id => $path) {
+            /** @var Folder $folder */
+            $folder = Folder::get()->byID($id);
+            $migratedPath = $this->migrateFolder($filesystem, $folder->getFilename());
+            if ($migratedPath) {
+                $migrated[] = $migratedPath;
+            }
+        }
+
+        return $migrated;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * A "somewhat exact" match on file contents,
+     * to avoid deleting any customised files.
+     * Checks each line in a file, with some leeway
+     * for different base folders which are dynamically generated
+     * based on the context of a particular environment.
+     *
+     * @param string $content
+     * @return bool
+     */
+    public function htaccessMatch($content)
+    {
+        $regexes = $this->htaccessRegexes;
+        $lines = explode("\n", $content);
+
+        if (count($lines) != count($regexes)) {
+            return false;
+        }
+
+        foreach($lines as $i => $line) {
+            if (!preg_match($regexes[$i], $line)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Filesystem $filesystem
+     * @param string $path
+     * return string|null The path of the migrated file (if successful)
+     */
+    protected function migrateFolder(Filesystem $filesystem, $path)
+    {
+        $htaccessPath = $path . '.htaccess';
+
+        if (!$filesystem->has($htaccessPath)) {
+            return null;
+        }
+
+        $content = $filesystem->read($htaccessPath);
+
+        if ($this->htaccessMatch($content)) {
+            $filesystem->delete($htaccessPath);
+            $this->logger->info(sprintf(
+                'Removed obsolete secureassets .htaccess at %s',
+                $path
+            ));
+            return $htaccessPath;
+        } else {
+            $this->logger->warning(sprintf(
+                'Skipped non-standard htaccess file (not generated by secureassets?): %s',
+                $path
+            ));
+            return null;
+        }
+    }
+}

--- a/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\Dev\Tasks;
+
+use Silverstripe\Assets\Dev\TestAssetStore;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Filesystem;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Dev\Tasks\SecureAssetsMigrationHelper;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Dev\SapphireTest;
+
+class SecureAssetsMigrationHelperTest extends SapphireTest
+{
+    protected $usesTransactions = false;
+
+    protected static $fixture_file = 'SecureAssetsMigrationHelperTest.yml';
+
+    /**
+     * get the BASE_PATH for this test
+     *
+     * @return string
+     */
+    protected function getBasePath()
+    {
+        // Note that the actual filesystem base is the 'assets' subdirectory within this
+        return ASSETS_PATH . '/SecureAssetsMigrationHelperTest';
+    }
+
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Set backend root to /LegacyThumbnailMigrationHelperTest/assets
+        TestAssetStore::activate('SecureAssetsMigrationHelperTest/assets');
+
+        // Create all empty folders
+
+        foreach (File::get()->filter('ClassName', Folder::class) as $folder) {
+            /** @var $folder Folder */
+            $path = TestAssetStore::base_path() . '/' . $folder->generateFilename();
+            Filesystem::makeFolder($path);
+        }
+
+        // Ensure that each file has a local record file in this new assets base
+        foreach (File::get()->exclude('ClassName', Folder::class) as $file) {
+            /** @var $file File */
+            $file->setFromString('some content', $file->generateFilename());
+            $file->write();
+            $file->publishFile();
+        }
+    }
+
+    public function tearDown()
+    {
+        TestAssetStore::reset();
+        Filesystem::removeFolder($this->getBasePath());
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider dataMigrate
+     */
+    public function testMigrate($fixture, $htaccess, $expected)
+    {
+        $helper = new SecureAssetsMigrationHelper();
+
+        /** @var TestAssetStore $store */
+        $store = singleton(AssetStore::class); // will use TestAssetStore
+        $fs = $store->getPublicFilesystem();
+
+        /** @var Folder $folder */
+        $folder = $this->objFromFixture(Folder::class, $fixture);
+        $path = $folder->getFilename() . '.htaccess';
+        $fs->write($path, $htaccess);
+        $result = $helper->run($store);
+
+        $this->assertEquals($result, $expected ? [$path] : []);
+    }
+
+    public function dataMigrate()
+    {
+        $htaccess = <<<TXT
+RewriteEngine On
+RewriteBase /
+RewriteCond %{REQUEST_URI} ^(.*)$
+RewriteRule .* framework/main.php?url=%1 [QSA]
+TXT;
+
+        $htaccessModified = <<<TXT
+modified
+TXT;
+
+        return [
+            'Protected with valid htaccess' => [
+                'protected',
+                $htaccess,
+                true
+            ],
+            'Protected nested within unprotected, with valid htaccess' => [
+                'protected-sub',
+                $htaccess,
+                true
+            ],
+            // .htaccess files on parent folders are respected by Apache
+            // See SecureFileExtension->needsAccessFile()
+            'Unprotected nested within protected, with valid htaccess' => [
+                'protected-inherited',
+                $htaccess,
+                false
+            ],
+            'Unprotected' => [
+                'unprotected',
+                null,
+                false
+            ],
+            'Protected with modified htaccess' => [
+                'protected-with-modified-htaccess',
+                $htaccessModified,
+                false
+            ],
+        ];
+    }
+
+    public function testHtaccessMatchesExact()
+    {
+        $htaccess = <<<TXT
+RewriteEngine On
+RewriteBase /
+RewriteCond %{REQUEST_URI} ^(.*)$
+RewriteRule .* framework/main.php?url=%1 [QSA]
+TXT;
+
+        $helper = new SecureAssetsMigrationHelper();
+        $this->assertTrue($helper->htaccessMatch($htaccess));
+    }
+
+    public function testHtaccessDoesNotMatchWithAdditionsAtStart()
+    {
+        $htaccess = <<<TXT
+Other stuff
+RewriteEngine On
+RewriteBase /
+RewriteCond %{REQUEST_URI} ^(.*)$
+RewriteRule .* framework/main.php?url=%1 [QSA]
+TXT;
+
+        $helper = new SecureAssetsMigrationHelper();
+        $this->assertFalse($helper->htaccessMatch($htaccess));
+    }
+
+    public function testHtaccessDoesNotMatchWithAdditionsAtEnd()
+    {
+        $htaccess = <<<TXT
+RewriteEngine On
+RewriteBase /
+RewriteCond %{REQUEST_URI} ^(.*)$
+RewriteRule .* framework/main.php?url=%1 [QSA]
+
+Other stuff
+TXT;
+
+        $helper = new SecureAssetsMigrationHelper();
+        $this->assertFalse($helper->htaccessMatch($htaccess));
+    }
+
+    public function testHtaccessDoesNotMatchWithAdditionsInBetween()
+    {
+        $htaccess = <<<TXT
+RewriteEngine On
+RewriteBase /
+Other stuff
+RewriteCond %{REQUEST_URI} ^(.*)$
+RewriteRule .* framework/main.php?url=%1 [QSA]
+TXT;
+
+        $helper = new SecureAssetsMigrationHelper();
+        $this->assertFalse($helper->htaccessMatch($htaccess));
+    }
+
+}

--- a/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
@@ -178,5 +178,4 @@ TXT;
         $helper = new SecureAssetsMigrationHelper();
         $this->assertFalse($helper->htaccessMatch($htaccess));
     }
-
 }

--- a/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.yml
+++ b/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.yml
@@ -1,0 +1,23 @@
+SilverStripe\Assets\Folder:
+  parent-with-protected-sub:
+    Name: parent-with-protected-sub
+  protected-sub:
+    Name: protected-sub
+    CanViewType: LoggedInUsers
+    Parent: =>SilverStripe\Assets\Folder.parent-with-protected-sub
+  unprotected:
+    Name: unprotected
+  protected:
+    Name: protected
+    CanViewType: LoggedInUsers
+  protected-inherited:
+    Name: protected-inherited
+    CanViewType: Inherit
+    Parent: =>SilverStripe\Assets\Folder.protected
+  protected-with-modified-htaccess:
+    Name: protected-with-modified-htaccess
+    CanViewType: LoggedInUsers
+SilverStripe\Assets\Image:
+  nested:
+    Name: nested.jpg
+    ParentID: =>SilverStripe\Assets\Folder.protected-sub


### PR DESCRIPTION
See htaccess file contents at https://github.com/silverstripe/silverstripe-secureassets/blob/f9d54e7b419574e583f3b958a2f21db163877971/_config.php#L9

Merge after https://github.com/silverstripe/silverstripe-framework/pull/8948

~Rebased on commits from https://github.com/silverstripe/silverstripe-assets/issues/235 since that's required to split up the migration tasks~

This task can't go into the secureassets module, since it needs to be run *after* dev/build on a 4.x compatible codebase. The secureassets module isn't 4.x compatible, so we can't execute code from it. Also, the current `MigrateFileTask` isn't extensible on that level, and I'm not really keen to do that