### PR TITLE
BUG Escape table name and column with double quote to fix PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - export PATH=~/.config/composer/vendor/bin:$PATH
-  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'memory_limit = 3G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 # Install composer dependencies
   - composer validate


### PR DESCRIPTION
PostgreSQL test were failing because of some missing double quotes.

I've also remove a try/catch to avoid hiding errors.

I'm still looking at how to fix the Coverage memory failure, so maybe hold back approving until then.