### PR TITLE
BUG Avoid locking framework version when installing postgresql module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - composer validate
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update silverstripe/recipe-core:1.1.x-dev silverstripe/versioned:1.1.x-dev
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
+  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - composer update --prefer-dist
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - composer validate
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update silverstripe/recipe-core:1.1.x-dev silverstripe/versioned:1.1.x-dev
-  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - composer update --prefer-dist
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 


### PR DESCRIPTION
The travis config was installing silverstripe/postresql right away which would install and lock framework at 4.3 and would break the build.