### PR TITLE
BUGFIX: File::canView() not considerate of ADMIN privileges

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -366,6 +366,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             return $result;
         }
 
+        if (Permission::checkMember($member, 'ADMIN')) {
+        	return true;
+        }
+
         // Check inherited permissions
         return static::getPermissionChecker()
             ->canView($this->ID, $member);

--- a/src/File.php
+++ b/src/File.php
@@ -367,7 +367,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         }
 
         if (Permission::checkMember($member, 'ADMIN')) {
-        	return true;
+            return true;
         }
 
         // Check inherited permissions


### PR DESCRIPTION
The `canView()` API had no test coverage and was allowing for scenarios where non-admin users could set permissions that made it impossible for admins to view or edit their files in the CMS.