### PR TITLE
Don't confuse 10-char folder with hash

### DIFF
--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -40,6 +40,13 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
      */
     private $versionedStage = Versioned::DRAFT;
 
+    /**
+     * todo: needs documenting
+     *
+     * @param string $fileID
+     * @param Filesystem $filesystem
+     * @return null|ParsedFileID
+     */
     public function resolveFileID($fileID, Filesystem $filesystem)
     {
         $parsedFileID = $this->parseFileID($fileID);
@@ -52,6 +59,13 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         return null;
     }
 
+    /**
+     * todo: needs documenting
+     *
+     * @param string $fileID
+     * @param Filesystem $filesystem
+     * @return null|ParsedFileID
+     */
     public function softResolveFileID($fileID, Filesystem $filesystem)
     {
         // If File is not versionable, let's bail
@@ -368,6 +382,14 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         );
     }
 
+    /**
+     * todo: needs documenting
+     *
+     * @param array|ParsedFileID $tuple
+     * @param Filesystem $filesystem
+     * @return \Generator|null|ParsedFileID[]
+     * @throws \League\Flysystem\FileNotFoundException
+     */
     public function findVariants($tuple, Filesystem $filesystem)
     {
         $parsedFileID = $this->preProcessTuple($tuple);
@@ -393,13 +415,13 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
                 }
             } catch (InvalidArgumentException $ex) {
                 // Our helper couldn't build a FileID with the provided arguments, that means it's not a valid helper
-                // fo this file tuple.
+                // for this tuple.
             }
         }
 
         // Loop through the list of possible helpers
         foreach ($resolvableHelpers as $helper) {
-            // Make sure our yield file has an hash
+            // Make sure our yield file has a hash
             $hash = $parsedFileID->getHash() ?: $this->findHashOf($helper, $parsedFileID, $filesystem);
 
             // Find the correct folder to search for possible variants in
@@ -446,6 +468,12 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         return null;
     }
 
+    /**
+     * todo: needs documenting
+     *
+     * @param ParsedFileID|string $fileID
+     * @return null|ParsedFileID
+     */
     public function stripVariant($fileID)
     {
         $hash = '';

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -402,7 +402,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
             // Make sure our yield file has an hash
             $hash = $parsedFileID->getHash() ?: $this->findHashOf($helper, $parsedFileID, $filesystem);
 
-            // Find the correct folder to searcg for possible variants in
+            // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
             $possibleVariants = $filesystem->listContents($folder, true);
 

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -42,10 +42,14 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 
     public function resolveFileID($fileID, Filesystem $filesystem)
     {
-        $parsedFileID = $this->parseFileID($fileID);
-
-        if ($parsedFileID) {
-            return $this->searchForTuple($parsedFileID, $filesystem, false);
+        foreach ($this->resolutionFileIDHelpers as $fileIDHelper) {
+            $parsedFileID = $fileIDHelper->parseFileID($fileID);
+            if ($parsedFileID) {
+                $foundTuple = $this->searchForTuple($parsedFileID, $filesystem, true);
+                if ($foundTuple) {
+                    return $foundTuple;
+                }
+            }
         }
 
         // If we couldn't resolve the file ID, we bail

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -40,13 +40,6 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
      */
     private $versionedStage = Versioned::DRAFT;
 
-    /**
-     * todo: needs documenting
-     *
-     * @param string $fileID
-     * @param Filesystem $filesystem
-     * @return null|ParsedFileID
-     */
     public function resolveFileID($fileID, Filesystem $filesystem)
     {
         $parsedFileID = $this->parseFileID($fileID);
@@ -59,13 +52,6 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         return null;
     }
 
-    /**
-     * todo: needs documenting
-     *
-     * @param string $fileID
-     * @param Filesystem $filesystem
-     * @return null|ParsedFileID
-     */
     public function softResolveFileID($fileID, Filesystem $filesystem)
     {
         // If File is not versionable, let's bail
@@ -382,14 +368,6 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         );
     }
 
-    /**
-     * todo: needs documenting
-     *
-     * @param array|ParsedFileID $tuple
-     * @param Filesystem $filesystem
-     * @return \Generator|null|ParsedFileID[]
-     * @throws \League\Flysystem\FileNotFoundException
-     */
     public function findVariants($tuple, Filesystem $filesystem)
     {
         $parsedFileID = $this->preProcessTuple($tuple);
@@ -415,14 +393,15 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
                 }
             } catch (InvalidArgumentException $ex) {
                 // Our helper couldn't build a FileID with the provided arguments, that means it's not a valid helper
-                // for this tuple.
+                // for this file tuple.
             }
         }
 
         // Loop through the list of possible helpers
         foreach ($resolvableHelpers as $helper) {
-            // Make sure our yield file has a hash
+            // Make sure our yield file has an hash
             $hash = $parsedFileID->getHash() ?: $this->findHashOf($helper, $parsedFileID, $filesystem);
+
 
             // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
@@ -468,12 +447,6 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         return null;
     }
 
-    /**
-     * todo: needs documenting
-     *
-     * @param ParsedFileID|string $fileID
-     * @return null|ParsedFileID
-     */
     public function stripVariant($fileID)
     {
         $hash = '';

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -79,7 +79,7 @@ class HashFileIDHelper implements FileIDHelper
 
     public function parseFileID($fileID)
     {
-        $pattern = '#^(?<folder>([^/]+/)*)(?<hash>[a-zA-Z0-9]{10})/(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
+        $pattern = '#^(?<folder>([^/]+/)*)(?<hash>[a-f0-9]{10})/(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
 
         // not a valid file (or not a part of the filesystem)
         if (!preg_match($pattern, $fileID, $matches)) {

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -390,14 +390,17 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
             list($fs, $strategy, $visibility) = $set;
 
             if ($fs->has($fileID)) {
-                $response = $callable(
-                    $strategy->resolveFileID($fileID, $fs),
-                    $fs,
-                    $strategy,
-                    $visibility
-                );
-                if ($response !== false) {
-                    return $response;
+                $parsedFileID = $strategy->resolveFileID($fileID, $fs);
+                if ($parsedFileID) {
+                    $response = $callable(
+                        $parsedFileID,
+                        $fs,
+                        $strategy,
+                        $visibility
+                    );
+                    if ($response !== false) {
+                        return $response;
+                    }
                 }
             }
         }

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -341,6 +341,7 @@ class FileMigrationHelperTest extends SapphireTest
             $bad->File->getHash(),
             "bad_name-v2.doc has the expected hash"
         );
+    }
 
     /**
      * Run the same battery of test but with legacy file name enabled.

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -59,6 +59,13 @@ class FileMigrationHelperTest extends SapphireTest
         /** @var \League\Flysystem\Filesystem $fs */
         $fs = Injector::inst()->get(AssetStore::class)->getPublicFilesystem();
 
+        $badnameID = $this->idFromFixture(File::class, 'badname');
+        SQLUpdate::create(
+            '"File"',
+            ['"Filename"' => 'assets/ParentFolder/bad__name.zip', '"Name"' => 'bad__name.zip'],
+            ['"ID"' => $badnameID]
+        )->execute();
+
         // Ensure that each file has a local record file in this new assets base
         foreach (File::get()->filter('ClassName', File::class) as $file) {
             $filename = $file->generateFilename();
@@ -342,6 +349,12 @@ class FileMigrationHelperTest extends SapphireTest
             $bad->File->getHash(),
             "bad_name-v2.doc has the expected hash"
         );
+
+        // Test that SS3 files with invalid SS4 names, get correctly rename
+        /** @var File $badname */
+        $badname = $this->objFromFixture(File::class, 'badname');
+        $this->assertEquals('ParentFolder/bad_name.zip', $badname->getFilename());
+        $this->assertFileExists(TestAssetStore::base_path() . '/ParentFolder/bad_name.zip');
     }
 
     /**

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -55,16 +55,8 @@ class FileMigrationHelperTest extends SapphireTest
         TestAssetStore::activate('FileMigrationHelperTest/assets');
         $this->makingBadFilesBadAgain();
 
-
         /** @var \League\Flysystem\Filesystem $fs */
         $fs = Injector::inst()->get(AssetStore::class)->getPublicFilesystem();
-
-        $badnameID = $this->idFromFixture(File::class, 'badname');
-        SQLUpdate::create(
-            '"File"',
-            ['"Filename"' => 'assets/ParentFolder/bad__name.zip', '"Name"' => 'bad__name.zip'],
-            ['"ID"' => $badnameID]
-        )->execute();
 
         // Ensure that each file has a local record file in this new assets base
         foreach (File::get()->filter('ClassName', File::class) as $file) {
@@ -349,13 +341,6 @@ class FileMigrationHelperTest extends SapphireTest
             $bad->File->getHash(),
             "bad_name-v2.doc has the expected hash"
         );
-
-        // Test that SS3 files with invalid SS4 names, get correctly rename
-        /** @var File $badname */
-        $badname = $this->objFromFixture(File::class, 'badname');
-        $this->assertEquals('ParentFolder/bad_name.zip', $badname->getFilename());
-        $this->assertFileExists(TestAssetStore::base_path() . '/ParentFolder/bad_name.zip');
-    }
 
     /**
      * Run the same battery of test but with legacy file name enabled.

--- a/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
+++ b/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
@@ -68,6 +68,8 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
             ['root-file'],
             ['folder-file'],
             ['subfolder-file'],
+            ['multimedia-file'],
+            ['hashfolder-file'],
         ];
     }
 

--- a/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.yml
+++ b/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.yml
@@ -4,6 +4,10 @@ SilverStripe\Assets\Folder:
   sub-folder:
     Name: SubFolder
     ParentID: =>SilverStripe\Assets\Folder.folder
+  multimedia:
+    Name: Multimedia
+  hashfolder:
+    Name: abcdef01234
 SilverStripe\Assets\File:
   root-file:
     FileFilename: RootFile.txt
@@ -19,6 +23,16 @@ SilverStripe\Assets\File:
     FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
     Name: SubFolderFile.txt
     ParentID: =>SilverStripe\Assets\Folder.sub-folder
+  multimedia-file:
+    FileFilename: Multimedia/file-in-folder-with-10-char.pdf
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: file-in-folder-with-10-char.pdf
+    ParentID: =>SilverStripe\Assets\Folder.multimedia
+  hashfolder-file:
+    FileFilename: abcdef01234/file-in-folder-with-10-hexa-decimal-char.pdf
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: file-in-folder-with-10-char.pdf
+    ParentID: =>SilverStripe\Assets\Folder.hashfolder
 
 SilverStripe\Assets\Image:
   root-file:

--- a/tests/php/FilenameParsing/HashFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/HashFileIDHelperTest.php
@@ -93,6 +93,9 @@ class HashFileIDHelperTest extends FileIDHelperTester
             ['sam__resizeXYZ.jpg'],
             ['folder//sam.jpg'],
             ['folder/not10characters/sam.jpg'],
+            ['folder/10invachar/sam.jpg'],
+            ['folder/abcdef1234567890/more-than-10-hexadecimal-char.jpg'],
+            ['folder/abcdef/less-than-10-hexadecimal-char.jpg'],
         ];
     }
 

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -1066,6 +1066,40 @@ class AssetStoreTest extends SapphireTest
                 [$filename, $vNatural],
                 [$vLegacy, dirname($vLegacy), dirname(dirname($vLegacy))]
             ],
+
+            // Test files with a parent folder that could be confused for an hash folder
+            'natural path in public store with 10-char folder' => [
+                $public,
+                ['multimedia/video.mp4' => $content],
+                'multimedia/video.mp4',
+                ['multimedia/video.mp4'],
+                [],
+                'multimedia/video.mp4'
+            ],
+            'natural path in protected store with 10-char folder' => [
+                $protected,
+                ['multimedia/video.mp4' => $content],
+                'multimedia/video.mp4',
+                [$hashHelper->buildFileID('multimedia/video.mp4', $hash)],
+                [],
+                'multimedia/video.mp4'
+            ],
+            'natural path in public store with 10-hexadecimal-char folder' => [
+                $public,
+                ['0123456789/video.mp4' => $content],
+                '0123456789/video.mp4',
+                ['0123456789/video.mp4'],
+                [],
+                '0123456789/video.mp4'
+            ],
+            'natural path in protected store with 10-hexadecimal-char folder' => [
+                $protected,
+                ['abcdef7890/video.mp4' => $content],
+                'abcdef7890/video.mp4',
+                [$hashHelper->buildFileID('abcdef7890/video.mp4', $hash)],
+                [],
+                'abcdef7890/video.mp4'
+            ],
         ];
     }
 
@@ -1077,13 +1111,19 @@ class AssetStoreTest extends SapphireTest
      * @param array $expected
      * @param array $notExpected
      */
-    public function testNormalisePath($fsName, array $contents, $fileID, array $expected, array $notExpected = [])
-    {
+    public function testNormalisePath(
+        $fsName,
+        array $contents,
+        $fileID,
+        array $expected,
+        array $notExpected = [],
+        $expectedFilename = 'folder/file.txt'
+    ) {
         $this->writeDummyFiles($fsName, $contents);
 
         $results = $this->getBackend()->normalisePath($fileID);
 
-        $this->assertEquals('folder/file.txt', $results['Filename']);
+        $this->assertEquals($expectedFilename, $results['Filename']);
         $this->assertTrue(
             strpos(sha1("The quick brown fox jumps over the lazy dog."), $results['Hash']) === 0
         );


### PR DESCRIPTION
This PR tweaks the logic that resolve file ID to make sure that when the hash is found from the file ID, it is matches the actual hash of the file.

# Parent issue 
https://github.com/silverstripe/silverstripe-assets/issues/269