### PR TITLE
Get ShortCodeHelper to work with old filenames with double underscore

### DIFF
--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -251,13 +251,16 @@ class TagsToShortcodeHelper
         $pattern = sprintf('#^/?(%s/?)?#', ASSETS_DIR);
         $fileID = preg_replace($pattern, '', $src);
 
+        // Our file reference might be using invalid file name that will have been cleaned up by the migration task.
+        $fileID = $defaultFileIDHelper->cleanFilename($fileID);
+
         // Try resolving with public filesystem first
         $filesystem = $this->flysystemAssetStore->getPublicFilesystem();
-        $parsedFileId = $fileIDHelperResolutionStrategy->softResolveFileID($fileID, $filesystem);
+        $parsedFileId = $fileIDHelperResolutionStrategy->resolveFileID($fileID, $filesystem);
         if (!$parsedFileId) {
             // Try resolving with protected filesystem
             $filesystem = $this->flysystemAssetStore->getProtectedFilesystem();
-            $parsedFileId = $fileIDHelperResolutionStrategy->softResolveFileID($fileID, $filesystem);
+            $parsedFileId = $fileIDHelperResolutionStrategy->resolveFileID($fileID, $filesystem);
         }
 
         if (!$parsedFileId) {

--- a/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.yml
+++ b/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.yml
@@ -6,15 +6,25 @@ SilverStripe\Assets\Tests\Dev\Tasks\Shortcode\PseudoPage:
       <p id="image"><img src="/assets/myimage.jpg"></p>
       <p id="variant"><img src="/assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg" width="64" height="64"></p>
 
+SilverStripe\Assets\Folder:
+  decadefolder:
+    Name: decade80
+
 SilverStripe\Assets\Image:
   image1:
     Name: myimage.jpg
     FileFilename: myimage.jpg
     FileHash: 33be1b95cba0358fe54e8b13532162d52f97421c
-  imageHashPath:
-    Name: hash-path.jpg
-    FileFilename: hash-path.jpg
-    FileHash: ce65335ee6
+  underscoreFile:
+    Name: under_score.jpg
+    FileFilename: decade80/under_score.jpg
+    FileHash: 33be1b95cba0358fe54e8b13532162d52f97421c
+    Parent: =>SilverStripe\Assets\Folder.decadefolder
+  trippleUnderscoreFile:
+    Name: under_score.jpg
+    FileFilename: decade80/under_score-v2.jpg
+    FileHash: 33be1b95cba0358fe54e8b13532162d52f97421c
+    Parent: =>SilverStripe\Assets\Folder.decadefolder
 SilverStripe\Assets\File:
   document:
     Name: document.pdf


### PR DESCRIPTION
SS3 allowed files with double underscore. SS4 doesn't. The File Migration Helper will rename those files.

This PR update the Short code migration helper to look for the clean filenames.

# Parent issue
* #264 