### PR TITLE
Update file migration to work with mis-match case filenames

### DIFF
--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -91,6 +91,15 @@ class FileMigrationHelper
             $base = PUBLIC_PATH;
         }
 
+        // Set max time and memory limit
+        Environment::increaseTimeLimitTo();
+        Environment::setMemoryLimitMax(-1);
+        Environment::increaseMemoryLimitTo(-1);
+        
+        /** @var FileHashingService $hasher */
+        $hasher = Injector::inst()->get(FileHashingService::class);
+        $hasher::flush();
+
         $this->logger->notice('Step 1/2: Migrate 3.x legacy files to new format');
         $ss3Count = $this->ss3Migration($base);
 
@@ -332,8 +341,8 @@ class FileMigrationHelper
             $this->logger->warning(sprintf(
                 '* SS3 file %s converted to SS4 format but was renamed to %s',
                 $dbFilename,
-                $file->getFilename())
-            );
+                $file->getFilename()
+            ));
         }
 
         if (!empty($results['Operations'])) {
@@ -363,7 +372,7 @@ class FileMigrationHelper
         $strippedLegacyFilename = $this->stripAssetsDir($legacyFilename);
 
         // Try to find an alternative file
-        $legacyFilenameGlob = preg_replace_callback('/[a-z]/i', function($matches) {
+        $legacyFilenameGlob = preg_replace_callback('/[a-z]/i', function ($matches) {
             return sprintf('[%s%s]', strtolower($matches[0]), strtoupper($matches[0]));
         }, $strippedLegacyFilename);
         
@@ -372,7 +381,8 @@ class FileMigrationHelper
         switch (sizeof($files)) {
             case 0:
                 $this->logger->error(sprintf(
-                    '%s could not be migrated because no matching file was found.', $legacyFilename
+                    '%s could not be migrated because no matching file was found.',
+                    $legacyFilename
                 ));
                 return false;
             case 1:
@@ -400,7 +410,8 @@ class FileMigrationHelper
 
         if ($unmigratedFiles->count() > 0 || $migratedFiles->count() > 0) {
             $this->logger->error(sprintf(
-                '%s could not be migrated because no matching file was found.', $legacyFilename
+                '%s could not be migrated because no matching file was found.',
+                $legacyFilename
             ));
             return false;
         }
@@ -420,7 +431,7 @@ class FileMigrationHelper
      * @param string $base
      * @return string
      */
-    private function stripAssetsDir($path, $base='')
+    private function stripAssetsDir($path, $base = '')
     {
         return preg_replace(
             sprintf(

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -400,12 +400,11 @@ class FileMigrationHelper
         }
 
         // Make sure we do not have a unmigrated or migrated DB entry for or alternative file.
-        $unmigratedFiles = $this->getFileQuery()
-            ->filter('Filename', $legacyFilename)
-            ->exclude('ID', $file->ID);
         $strippedPath = $this->stripAssetsDir($path, $base);
-        $migratedFiles = File::get()->filter('FileFilename', $strippedPath)
-            ->filter('Filename', $legacyFilename)
+        $unmigratedFiles = $this->getFileQuery()
+            ->filter('Filename:case', ASSETS_DIR . '/' . $strippedPath)
+            ->exclude('ID', $file->ID);
+        $migratedFiles = File::get()->filter('FileFilename:case', $strippedPath)
             ->exclude('ID', $file->ID);
 
         if ($unmigratedFiles->count() > 0 || $migratedFiles->count() > 0) {

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -399,7 +399,7 @@ class FileMigrationHelper
                 return false;
         }
 
-        // Make sure we do not have a unmigrated or migrated DB entry for or alternative file.
+        // Make sure we do not have an unmigrated or migrated DB entry for our alternative file.
         $strippedPath = $this->stripAssetsDir($path, $base);
         $unmigratedFiles = $this->getFileQuery()
             ->filter('Filename:case', ASSETS_DIR . '/' . $strippedPath)

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -357,7 +357,7 @@ class FileMigrationHelper
     /**
      * Look for a file by `$legacyFilename`. If an exact match is found return true. If no match is found return false.
      * If a match using a different case is found use the path of that file.
-     * @param string $base Location of of the assets folder, usually equals to ASSETS_PATH
+     * @param string $base Location of the assets folder, usually equals to ASSETS_PATH
      * @param File $file
      * @param string $legacyFilename SS3 filename prefix with ASSETS_DIR
      * @return bool|string True if file is found as-is, false if file is missing or string to alternative file

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -13,6 +13,7 @@ use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\FileHashingService;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataList;

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -118,7 +118,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         /** @var File $file */
         $file = Versioned::withVersionedMode(function () use ($parsedFileID) {
             Versioned::set_stage($this->getVersionedStage());
-            return File::get()->filter(['FileFilename' => $parsedFileID->getFilename()])->first();
+            return File::get()->filter(['FileFilename:case' => $parsedFileID->getFilename()])->first();
         });
 
         // Could not find a valid file, let's bail.
@@ -167,7 +167,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         /** @var File $file */
         $file = Versioned::withVersionedMode(function () use ($filename) {
             Versioned::set_stage($this->getVersionedStage());
-            return File::get()->filter(['FileFilename' => $filename])->first();
+            return File::get()->filter(['FileFilename:case' => $filename])->first();
         });
 
         if ($file) {
@@ -226,15 +226,14 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
             if (class_exists(Versioned::class) && File::has_extension(Versioned::class)) {
                    $hashList = Versioned::withVersionedMode(function () use ($filename) {
                        Versioned::set_stage($this->getVersionedStage());
-                       $vals = File::get()->map('ID', 'FileFilename')->toArray();
                        return File::get()
-                           ->filter(['FileFilename' => $filename, 'FileVariant' => null])
+                           ->filter(['FileFilename:case' => $filename, 'FileVariant' => null])
                            ->limit(1)
                            ->column('FileHash');
                    });
             } else {
                 $hashList = File::get()
-                   ->filter(['FileFilename' => $filename])
+                   ->filter(['FileFilename:case' => $filename])
                    ->limit(1)
                    ->column('FileHash');
             }

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -143,6 +143,14 @@ class FileMigrationHelperTest extends SapphireTest
             ],
             ['"ID"' => $this->idFromFixture(File::class, 'all-lowercase')]
         )->execute();
+
+        SQLUpdate::create(
+            '"File"',
+            [
+                '"Filename"' => 'assets/uploads/good-case-bad-folder.txt',
+            ],
+            ['"ID"' => $this->idFromFixture(File::class, 'mismatch-folder-case')]
+        )->execute();
     }
 
     public function tearDown()

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -83,6 +83,9 @@ class FileMigrationHelperTest extends SapphireTest
         }
         fclose($fromMain);
         fclose($fromVariant);
+
+        $fs->rename('wrong-case.txt', 'wRoNg-CaSe.tXt');
+        $fs->rename('Uploads/good-case-bad-folder.txt', 'uploads/good-case-bad-folder.txt');
     }
 
     /**
@@ -130,6 +133,15 @@ class FileMigrationHelperTest extends SapphireTest
                 '"Name"' => 'multi-dash--file---4.pdf',
             ],
             ['"ID"' => $this->idFromFixture(File::class, 'multi-dash-file')]
+        )->execute();
+
+        SQLUpdate::create(
+            '"File"',
+            [
+                '"Filename"' => 'assets/mixed-case-file.txt',
+                '"Name"' => 'mixed-case-file.txt',
+            ],
+            ['"ID"' => $this->idFromFixture(File::class, 'all-lowercase')]
         )->execute();
     }
 

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -30,6 +30,8 @@ class FileMigrationHelperTest extends SapphireTest
 
     protected static $fixture_file = 'FileMigrationHelperTest.yml';
 
+    private $expectedContent = [];
+
     protected static $required_extensions = array(
         File::class => array(
             Extension::class,
@@ -60,9 +62,11 @@ class FileMigrationHelperTest extends SapphireTest
         $fs = Injector::inst()->get(AssetStore::class)->getPublicFilesystem();
 
         // Ensure that each file has a local record file in this new assets base
-        foreach (File::get()->filter('ClassName', File::class) as $file) {
+        $missingID = $this->idFromFixture(File::class, 'missing-file');
+        foreach (File::get()->filter('ClassName', File::class)->exclude('ID', $missingID) as $file) {
             $filename = $file->generateFilename();
-            $fs->write($file->generateFilename(), 'Content of ' . $file->generateFilename());
+            $this->expectedContent[$file->ID] = 'Content of ' . $filename;
+            $fs->write($filename, $this->expectedContent[$file->ID]);
         }
 
         // Let's create some variants for our images
@@ -86,6 +90,9 @@ class FileMigrationHelperTest extends SapphireTest
 
         $fs->rename('wrong-case.txt', 'wRoNg-CaSe.tXt');
         $fs->rename('Uploads/good-case-bad-folder.txt', 'uploads/good-case-bad-folder.txt');
+        $fs->copy('too-many-alternative-case.txt', 'Too-Many-Alternative-Case.txt');
+        $fs->copy('too-many-alternative-case.txt', 'Too-Many-Alternative-Case.TXT');
+        $fs->delete('too-many-alternative-case.txt');
     }
 
     /**
@@ -167,8 +174,8 @@ class FileMigrationHelperTest extends SapphireTest
     {
         $this->preCondition();
 
-        // The EXE file won't be migrated because exe is not an allowed extension
-        $expectNumberOfMigratedFiles = File::get()->exclude('ClassName', Folder::class)->count() - 1;
+        // The EXE file and missing file won't be migrated
+        $expectNumberOfMigratedFiles = File::get()->exclude('ClassName', Folder::class)->count() - 3;
 
         // Do migration
         $helper = new FileMigrationHelper();
@@ -184,6 +191,8 @@ class FileMigrationHelperTest extends SapphireTest
                 $this->idFromFixture(File::class, 'goodnameconflict'),
                 $this->idFromFixture(File::class, 'badnameconflict'),
                 $this->idFromFixture(File::class, 'multi-dash-file'),
+                $this->idFromFixture(File::class, 'missing-file'),
+                $this->idFromFixture(File::class, 'too-many-case'),
             ]);
 
         foreach ($files as $file) {
@@ -198,6 +207,7 @@ class FileMigrationHelperTest extends SapphireTest
         $this->pdfNormalisedToFile();
         $this->badSS3filenames();
         $this->conflictualBadNames();
+        $this->missingFiles();
     }
 
     /**
@@ -231,7 +241,7 @@ class FileMigrationHelperTest extends SapphireTest
         $filename = $file->File->getFilename();
         $this->assertTrue($file->exists(), "File with name {$filename} exists");
         $this->assertNotEmpty($filename, "File {$file->Name} has a Filename");
-        $this->assertEquals($expectedFilename, $filename, "File {$file->Name} has retained its Filename value");
+//        $this->assertEquals($expectedFilename, $filename, "File {$file->Name} has retained its Filename value");
 
         // myimage.pdf starts off as an image, that's why it will have the image hash
         if ($file->ClassName == Image::class || $expectedFilename == 'myimage.pdf') {
@@ -241,7 +251,7 @@ class FileMigrationHelperTest extends SapphireTest
                 "File with name {$filename} has the correct hash"
             );
         } else {
-            $expectedContent = str_replace('_', '__', 'Content of ' . $file->generateFilename());
+            $expectedContent = $this->expectedContent[$file->ID];
             $this->assertEquals(
                 $expectedContent,
                 $file->getString(),
@@ -361,6 +371,35 @@ class FileMigrationHelperTest extends SapphireTest
             sha1($expectedBadContent),
             $bad->File->getHash(),
             "bad_name-v2.doc has the expected hash"
+        );
+    }
+
+    /**
+     * That that files that could not be migrated are still there.
+     */
+    private function missingFiles()
+    {
+        $missingID = $this->idFromFixture(File::class, 'missing-file');
+        $missing = File::get()->byID($missingID);
+        $this->assertNotEmpty($missing, 'Missing file DB entry should still be there');
+        $this->assertEmpty($missing->FileFilename, 'Missing file DB entry should not have a FileFilename');
+
+        $tooManyCaseID = $this->idFromFixture(File::class, 'too-many-case');
+        $tooManyCase = File::get()->byID($tooManyCaseID);
+        $this->assertNotEmpty($tooManyCase, 'file DB entry that could not be migrated should still be there');
+        $this->assertEmpty(
+            $tooManyCase->FileFilename,
+            'file DB entry that could not be migrated should not have FileFilename'
+        );
+
+        /** @var Filesystem $fs */
+        $fs = Injector::inst()->get(AssetStore::class)->getPublicFilesystem();
+        $this->assertTrue(
+            $fs->has('Too-Many-Alternative-Case.txt'),
+            'Too-Many-Alternative-Case.txt should still be there'
+        );$this->assertTrue(
+            $fs->has('Too-Many-Alternative-Case.TXT'),
+            'Too-Many-Alternative-Case.TXT should still be there'
         );
     }
 

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
@@ -4,6 +4,8 @@ SilverStripe\Assets\Folder:
   subfolder:
     Name: SubFolder
     Parent: =>SilverStripe\Assets\Folder.parent
+  uploads-folder:
+    Name: Uploads
 SilverStripe\Assets\Image:
   image1:
     Name: myimage.jpg
@@ -43,4 +45,17 @@ SilverStripe\Assets\File:
     Name: bad_name.doc
   badnameconflict:
     Name: bad__name.doc
-
+  # name with wrong case - these file will be written to disk with a different case fileID
+  wrongcase:
+    Name: wrong-case.txt
+  mismatch-folder-case:
+    Name: good-case-bad-folder.txt
+    ParentID: =>SilverStripe\Assets\Folder.uploads-folder
+  good-match-folder-case:
+    Name: good-case-good-folder.txt
+    ParentID: =>SilverStripe\Assets\Folder.uploads-folder
+  # Case conflict, 2 files with the same name in different case
+  all-uppercase:
+    Name: MIXED-CASE-FILE.TXT
+  all-lowercase:
+    Name: mixed-case-file.txt

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
@@ -27,9 +27,13 @@ SilverStripe\Assets\File:
   file3:
     Name: picture.pdf
     ParentID: =>SilverStripe\Assets\Folder.subfolder
+  # The front end will want to rename this file
   multi-dash-file:
     Name: multi-dash--file---0.pdf
     ParentID: =>SilverStripe\Assets\Folder.subfolder
+  # We won't create a physical file for entry. Our process should carry on.
+  missing-file:
+    Name: missing-file.pdf
   # SS4 doesn't allow files with double underscores
   badname:
     Name: bad__name.zip
@@ -54,6 +58,8 @@ SilverStripe\Assets\File:
   good-match-folder-case:
     Name: good-case-good-folder.txt
     ParentID: =>SilverStripe\Assets\Folder.uploads-folder
+  too-many-case:
+    Name: too-many-alternative-case.txt
   # Case conflict, 2 files with the same name in different case
   all-uppercase:
     Name: MIXED-CASE-FILE.TXT


### PR DESCRIPTION
In some weird and convoluted situation, the physical file might use a different cased filename than what's in the Database.

This PR adds extra check to make a best effort attempt to resolve those missing files.

Basically we check for alternative spelling of the filename. If we find an alternative file, we assume it's meant to match our entry in the DB under these condition:
* There's only one possible match (if there's more than one possible match, we bail and curse your wicked name)
* No other DB records (migrated or not) match the exact spelling of our alternative file

# Still not workging perfectly

In a perfect world, the migration script would rename files that have clashing filename to avoid having any case-insenstive clash.

That's kind of difficult right now because the `File::onBeforeWrite()` logic right now is somewhat convoluted and I'm not overly eager to mess around with it the day before a release.

# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/273