### PR TITLE
API Remove coupling from Versioned

### DIFF
--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -114,7 +114,10 @@ class TagsToShortcodeHelper
         foreach ($classes as $class => $tables) {
             /** @var DataObject $singleton */
             $singleton = singleton($class);
-            $hasVersions = $singleton->hasExtension(Versioned::class) && $singleton->hasStages();
+            $hasVersions =
+                class_exists(Versioned::class) &&
+                $singleton->hasExtension(Versioned::class) &&
+                $singleton->hasStages();
 
             foreach ($tables as $table => $fields) {
                 foreach ($fields as $field) {
@@ -295,7 +298,7 @@ class TagsToShortcodeHelper
 
         /** @var File $file */
         $file = File::get()->filter('FileFilename', $parsedFileID->getFilename())->first();
-        if (!$file) {
+        if (!$file && class_exists(Versioned::class)) {
             $file = Versioned::withVersionedMode(function () use ($parsedFileID) {
                 Versioned::set_stage(Versioned::LIVE);
                 return File::get()->filter('FileFilename', $parsedFileID->getFilename())->first();

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -44,7 +44,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
      * Constrain this strategy to the a specific versioned stage.
      * @var string
      */
-    private $versionedStage = Versioned::DRAFT;
+    private $versionedStage = '';
 
     /** @var FileHashingService */
     private $hasher;
@@ -52,6 +52,13 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
     private static $dependencies = [
         'FileHashingService' => '%$' . FileHashingService::class
     ];
+
+    public function __construct()
+    {
+        if (class_exists(Versioned::class)) {
+            $this->versionedStage = Versioned::DRAFT;
+        }
+    }
 
     public function setFileHashingService($service)
     {


### PR DESCRIPTION
Added a bunch of `class_exists(Versioned::class)` statement to make sure the module doesn't fall on its face when run without Versioned.