### PR TITLE
BUG Unset memory limit max so we can increase memory limit

### DIFF
--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -95,7 +95,8 @@ class FileMigrationHelper
 
         // Set max time and memory limit
         Environment::increaseTimeLimitTo();
-        Environment::increaseMemoryLimitTo();
+        Environment::setMemoryLimitMax(-1);
+        Environment::increaseMemoryLimitTo(-1);
 
         $this->logger->info('MIGRATING SILVERSTRIPE 3 LEGACY FILES');
         $ss3Count = $this->ss3Migration($base);

--- a/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
+++ b/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
@@ -69,7 +69,8 @@ class LegacyThumbnailMigrationHelper
 
         // Set max time and memory limit
         Environment::increaseTimeLimitTo();
-        Environment::increaseMemoryLimitTo();
+        Environment::setMemoryLimitMax(-1);
+        Environment::increaseMemoryLimitTo(-1);
 
         // Loop over all folders
         $allMoved = [];


### PR DESCRIPTION
Apparently `increaseMemoryLimitTo` doesn't do anything unless you unset memory limit max, which sounds kind of weird.

I think we should look into that as well, but short term, let's just get the file migration to use as much memory as it wants.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/9029