### PR TITLE
BUG Make FileIDHelperResolutionStrategy Injectable.

### DIFF
--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -227,10 +227,9 @@ class FileMigrationHelper
         }
 
         // Build the migration strategy
-        $ss3Strategy = new FileIDHelperResolutionStrategy();
+        $ss3Strategy = FileIDHelperResolutionStrategy::create();
         $ss3Strategy->setDefaultFileIDHelper($initialStrategy->getDefaultFileIDHelper());
         $ss3Strategy->setResolutionFileIDHelpers([new LegacyFileIDHelper(false)]);
-        $ss3Strategy->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         return $ss3Strategy;
     }

--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -242,7 +242,7 @@ class TagsToShortcodeHelper
      */
     private function getParsedFileIDFromSrc($src)
     {
-        $fileIDHelperResolutionStrategy = new FileIDHelperResolutionStrategy();
+        $fileIDHelperResolutionStrategy = FileIDHelperResolutionStrategy::create();
         $fileIDHelperResolutionStrategy->setResolutionFileIDHelpers([
             $hashFileIdHelper = new HashFileIDHelper(),
             new LegacyFileIDHelper(),

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use League\Flysystem\Filesystem;
 use SilverStripe\Assets\Storage\FileHashingService;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Assets\File;
@@ -26,7 +27,7 @@ use SilverStripe\ORM\DB;
 class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 {
     use Configurable;
-
+    use Injectable;
 
     /**
      * The FileID helper that will be use to build FileID for this adapter.

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -359,7 +359,7 @@ class FileMigrationHelperTest extends SapphireTest
      */
     public function testInvalidAssetStoreStrategy()
     {
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper(new HashFileIDHelper());
         $strategy->setResolutionFileIDHelpers([new HashFileIDHelper()]);
 

--- a/tests/php/Dev/Tasks/SS4CrazyFileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SS4CrazyFileMigrationHelperTest.php
@@ -30,19 +30,17 @@ class SS4CrazyFileMigrationHelperTest extends SS4FileMigrationHelperTest
         $hashHelper = new HashFileIDHelper();
         $legacyHelper = new LegacyFileIDHelper();
 
-        $protected = new FileIDHelperResolutionStrategy();
+        $protected = FileIDHelperResolutionStrategy::create();
         $protected->setVersionedStage(Versioned::DRAFT);
         $protected->setDefaultFileIDHelper($hashHelper);
         $protected->setResolutionFileIDHelpers([$hashHelper]);
-        $protected->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setProtectedResolutionStrategy($protected);
 
-        $public = new FileIDHelperResolutionStrategy();
+        $public = FileIDHelperResolutionStrategy::create();
         $public->setVersionedStage(Versioned::LIVE);
         $public->setDefaultFileIDHelper($legacyHelper);
         $public->setResolutionFileIDHelpers([$legacyHelper]);
-        $public->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setPublicResolutionStrategy($public);
     }
@@ -56,20 +54,17 @@ class SS4CrazyFileMigrationHelperTest extends SS4FileMigrationHelperTest
         $naturalPath = new NaturalFileIDHelper();
         $legacyHelper = new LegacyFileIDHelper();
 
-        $protected = new FileIDHelperResolutionStrategy();
+        $protected = FileIDHelperResolutionStrategy::create();
         $protected->setVersionedStage(Versioned::DRAFT);
         $protected->setDefaultFileIDHelper($hashHelper);
         $protected->setResolutionFileIDHelpers([$hashHelper]);
-        $protected->setFileHashingService(Injector::inst()->get(FileHashingService::class));
-
 
         $store->setProtectedResolutionStrategy($protected);
 
-        $public = new FileIDHelperResolutionStrategy();
+        $public = FileIDHelperResolutionStrategy::create();
         $public->setVersionedStage(Versioned::LIVE);
         $public->setDefaultFileIDHelper($hashHelper);
         $public->setResolutionFileIDHelpers([$hashHelper, $naturalPath, $legacyHelper]);
-        $public->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setPublicResolutionStrategy($public);
     }

--- a/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
@@ -139,19 +139,17 @@ class SS4FileMigrationHelperTest extends SapphireTest
 
         $hashHelper = new HashFileIDHelper();
 
-        $protected = new FileIDHelperResolutionStrategy();
+        $protected = FileIDHelperResolutionStrategy::create();
         $protected->setVersionedStage(Versioned::DRAFT);
         $protected->setDefaultFileIDHelper($hashHelper);
         $protected->setResolutionFileIDHelpers([$hashHelper]);
-        $protected->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setProtectedResolutionStrategy($protected);
 
-        $public = new FileIDHelperResolutionStrategy();
+        $public = FileIDHelperResolutionStrategy::create();
         $public->setVersionedStage(Versioned::LIVE);
         $public->setDefaultFileIDHelper($hashHelper);
         $public->setResolutionFileIDHelpers([$hashHelper]);
-        $public->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setPublicResolutionStrategy($public);
     }
@@ -168,19 +166,17 @@ class SS4FileMigrationHelperTest extends SapphireTest
         $hashHelper = new HashFileIDHelper();
         $naturalHelper = new NaturalFileIDHelper();
 
-        $protected = new FileIDHelperResolutionStrategy();
+        $protected = FileIDHelperResolutionStrategy::create();
         $protected->setVersionedStage(Versioned::DRAFT);
         $protected->setDefaultFileIDHelper($hashHelper);
         $protected->setResolutionFileIDHelpers([$hashHelper, $naturalHelper]);
-        $protected->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setProtectedResolutionStrategy($protected);
 
-        $public = new FileIDHelperResolutionStrategy();
+        $public = FileIDHelperResolutionStrategy::create();
         $public->setVersionedStage(Versioned::LIVE);
         $public->setDefaultFileIDHelper($naturalHelper);
         $public->setResolutionFileIDHelpers([$hashHelper, $naturalHelper]);
-        $public->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setPublicResolutionStrategy($public);
     }

--- a/tests/php/Dev/Tasks/SS4LegacyFileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SS4LegacyFileMigrationHelperTest.php
@@ -24,20 +24,17 @@ class SS4LegacyFileMigrationHelperTest extends SS4FileMigrationHelperTest
 
         $naturalHelper = new NaturalFileIDHelper();
 
-        $protected = new FileIDHelperResolutionStrategy();
+        $protected = FileIDHelperResolutionStrategy::create();
         $protected->setVersionedStage(Versioned::DRAFT);
         $protected->setDefaultFileIDHelper($naturalHelper);
         $protected->setResolutionFileIDHelpers([$naturalHelper]);
-        $protected->setFileHashingService(Injector::inst()->get(FileHashingService::class));
 
         $store->setProtectedResolutionStrategy($protected);
 
-        $public = new FileIDHelperResolutionStrategy();
+        $public = FileIDHelperResolutionStrategy::create();
         $public->setVersionedStage(Versioned::LIVE);
         $public->setDefaultFileIDHelper($naturalHelper);
         $public->setResolutionFileIDHelpers([$naturalHelper]);
-        $public->setFileHashingService(Injector::inst()->get(FileHashingService::class));
-
 
         $store->setPublicResolutionStrategy($public);
     }

--- a/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
+++ b/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
@@ -100,7 +100,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = sha1('version 1');
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($helper);
         $strategy->setResolutionFileIDHelpers([$helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -127,7 +127,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = sha1('version 1');
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($mockHelper);
         $strategy->setResolutionFileIDHelpers([$mockHelper, $helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -152,7 +152,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = sha1('broken content that does not mtach the expected content');
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($mockHelper);
         $strategy->setResolutionFileIDHelpers([$mockHelper, $helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -177,7 +177,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = sha1('version 1');
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($helper);
         $strategy->setResolutionFileIDHelpers([$helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -219,7 +219,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = $newerHash;
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($helper);
         $strategy->setResolutionFileIDHelpers([$helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -253,7 +253,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $fileDO->FileHash = sha1('version 1');
         $fileDO->write();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($mockHelper);
         $strategy->setResolutionFileIDHelpers([$mockHelper, $helper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -286,7 +286,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
 
         $fileDO->publishSingle();
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($brokenHelper);
         $strategy->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
@@ -315,25 +315,21 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         );
 
         $parsedFileID = $mockHelper->parseFileID($expected);
-        $hashingService = new Sha1FileHashingService();
 
-        $defaultResolves = new FileIDHelperResolutionStrategy();
+        $defaultResolves = FileIDHelperResolutionStrategy::create();
         $defaultResolves->setDefaultFileIDHelper($mockHelper);
         $defaultResolves->setResolutionFileIDHelpers([$brokenHelper]);
         $defaultResolves->setVersionedStage(Versioned::DRAFT);
-        $defaultResolves->setFileHashingService($hashingService);
 
-        $secondaryResolves = new FileIDHelperResolutionStrategy();
+        $secondaryResolves = FileIDHelperResolutionStrategy::create();
         $secondaryResolves->setDefaultFileIDHelper($brokenHelper);
         $secondaryResolves->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);
         $secondaryResolves->setVersionedStage(Versioned::DRAFT);
-        $secondaryResolves->setFileHashingService($hashingService);
 
-        $secondaryResolvesLive = new FileIDHelperResolutionStrategy();
+        $secondaryResolvesLive = FileIDHelperResolutionStrategy::create();
         $secondaryResolvesLive->setDefaultFileIDHelper($brokenHelper);
         $secondaryResolvesLive->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);
         $secondaryResolvesLive->setVersionedStage(Versioned::LIVE);
-        $secondaryResolvesLive->setFileHashingService($hashingService);
 
         return [
             [$defaultResolves, $parsedFileID, $expected],
@@ -383,13 +379,12 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
     public function testHashlessSearchForTuple()
     {
         // Set up strategy
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $hashHelper = new HashFileIDHelper();
         $naturalHelper = new NaturalFileIDHelper();
         $strategy->setDefaultFileIDHelper($hashHelper);
         $strategy->setResolutionFileIDHelpers([$hashHelper, $naturalHelper]);
         $strategy->setVersionedStage(Versioned::DRAFT);
-        $strategy->setFileHashingService(new Sha1FileHashingService());
 
         // Set up some dummy file
         $content = "The quick brown fox jumps over the lazy dog.";
@@ -473,25 +468,21 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         );
 
         $parsedFileID = $mockHelper->parseFileID('Folder/FolderFile.pdf');
-        $hashingService = new Sha1FileHashingService();
 
-        $defaultResolves = new FileIDHelperResolutionStrategy();
+        $defaultResolves = FileIDHelperResolutionStrategy::create();
         $defaultResolves->setDefaultFileIDHelper($mockHelper);
         $defaultResolves->setResolutionFileIDHelpers([$brokenHelper]);
         $defaultResolves->setVersionedStage(Versioned::DRAFT);
-        $defaultResolves->setFileHashingService($hashingService);
 
-        $secondaryResolves = new FileIDHelperResolutionStrategy();
+        $secondaryResolves = FileIDHelperResolutionStrategy::create();
         $secondaryResolves->setDefaultFileIDHelper($brokenHelper);
         $secondaryResolves->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);
         $secondaryResolves->setVersionedStage(Versioned::DRAFT);
-        $secondaryResolves->setFileHashingService($hashingService);
 
-        $secondaryResolvesLive = new FileIDHelperResolutionStrategy();
+        $secondaryResolvesLive = FileIDHelperResolutionStrategy::create();
         $secondaryResolvesLive->setDefaultFileIDHelper($brokenHelper);
         $secondaryResolvesLive->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);
         $secondaryResolvesLive->setVersionedStage(Versioned::LIVE);
-        $secondaryResolvesLive->setFileHashingService($hashingService);
 
         return [
             [$defaultResolves, $parsedFileID],
@@ -535,10 +526,9 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
 
     public function testFindHashlessVariant()
     {
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
         $strategy->setDefaultFileIDHelper($naturalHelper = new NaturalFileIDHelper());
         $strategy->setResolutionFileIDHelpers([new HashFileIDHelper()]);
-        $strategy->setFileHashingService(new Sha1FileHashingService());
 
         $expectedHash = sha1('version 1');
 
@@ -581,7 +571,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
             'Folder'
         );
 
-        $strategy = new FileIDHelperResolutionStrategy();
+        $strategy = FileIDHelperResolutionStrategy::create();
 
         // Test that file ID gets resolved properly if a functional helper is provided
         $strategy->setResolutionFileIDHelpers([$brokenHelper, $mockHelper]);

--- a/tests/php/Flysystem/FlysystemAssetStoreTest.php
+++ b/tests/php/Flysystem/FlysystemAssetStoreTest.php
@@ -168,7 +168,7 @@ class FlysystemAssetStoreTest extends SapphireTest
         $expected = Injector::inst()->get(FileResolutionStrategy::class . '.public');
         $this->assertEquals($expected, $strategy);
 
-        $expected = new FileIDHelperResolutionStrategy();
+        $expected = FileIDHelperResolutionStrategy::create();
         $assetStore->setPublicResolutionStrategy($expected);
         $strategy = $assetStore->getPublicResolutionStrategy();
         $this->assertEquals($expected, $strategy);
@@ -181,7 +181,7 @@ class FlysystemAssetStoreTest extends SapphireTest
         $expected = Injector::inst()->get(FileResolutionStrategy::class . '.protected');
         $this->assertEquals($expected, $strategy);
 
-        $expected = new FileIDHelperResolutionStrategy();
+        $expected = FileIDHelperResolutionStrategy::create();
         $assetStore->setProtectedResolutionStrategy($expected);
         $strategy = $assetStore->getProtectedResolutionStrategy();
         $this->assertEquals($expected, $strategy);


### PR DESCRIPTION
Sometimes the hasher on FileIDHelperResolutionStrategy is null because `FileIDHelperResolutionStrategy` was not injectable.