### PR TITLE
Fix the `TagsToShortcodeTask` segment so it matches the class name

### DIFF
--- a/src/Dev/Tasks/TagsToShortcodeTask.php
+++ b/src/Dev/Tasks/TagsToShortcodeTask.php
@@ -13,7 +13,7 @@ use SilverStripe\Dev\BuildTask;
  */
 class TagsToShortcodeTask extends BuildTask
 {
-    private static $segment = 'TagsToShortcode';
+    private static $segment = 'TagsToShortcodeTask';
 
     protected $title = 'Rewrite tags to shortcodes';
 


### PR DESCRIPTION
Every other BuildTask does it this way.