### PR TITLE
ImageManipulation.php API documentation fix

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -660,7 +660,7 @@ trait ImageManipulation
     /**
      * Thubnail generation for all file types.
      *
-     * Resizes images, but returns an icon <img /> tag if this is not a resizable image
+     * Resizes images, but returns an icon `<img />` tag if this is not a resizable image
      *
      * @param int $width
      * @param int $height


### PR DESCRIPTION
The API documentation for ImageManipulation has a minor problem. The ThumbnailIcon function description is missing the `<img />` tag text in the description:
https://api.silverstripe.org/4/SilverStripe/Assets/ImageManipulation.html#method_ThumbnailIcon

This is because the `<img />` tag is unescaped in the function documentation. 

This fix changes the tag to be escaped.