### PR TITLE
BUG Update FileIDHelperResolutionStrategy::stripVariant to work with hexadecimal folders

### DIFF
--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -502,6 +502,12 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
         foreach ($this->resolutionFileIDHelpers as $fileIDHelper) {
             $parsedFileID = $fileIDHelper->parseFileID($fileID);
             if ($parsedFileID) {
+                if ($hash && $parsedFileID->getHash() && !$this->hasher->compare($parsedFileID->getHash(), $hash)) {
+                    // Our file ID came bundled with an Hash, we got an hash from our helper, but that hash didn't
+                    // match what we were expecting.
+                    continue;
+                }
+
                 if ($hash) {
                     $parsedFileID = $parsedFileID->setHash($hash);
                 }

--- a/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
+++ b/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
@@ -646,6 +646,7 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
     public function listVariantParsedFiledID()
     {
         $pfid = new ParsedFileID('folder/file.txt', 'abcdef7890');
+        $ambigious = new ParsedFileID('decade1980/file.txt', 'abcdef7890');
         return [
             'Variantless Natural path' =>
                 [$pfid->setFileID('folder/file.txt')->setHash(''), 'folder/file.txt'],
@@ -669,6 +670,14 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
                     $pfid->setFileID('folder/abcdef7890/file.txt'),
                     $pfid->setFileID('folder/abcdef7890/file__variant.txt')
                 ],
+            'File in folder that could be an hash' => [
+                $ambigious->setFileID('decade1980/file.txt'),
+                $ambigious->setFileID('decade1980/file.txt'),
+            ],
+            'File variant in folder that could be an hash' => [
+                $ambigious->setFileID('decade1980/file.txt'),
+                $ambigious->setFileID('decade1980/file__variant.txt')->setVariant('variant'),
+            ]
         ];
     }
 

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -1163,4 +1163,36 @@ class AssetStoreTest extends SapphireTest
             $fs->write($path, $content);
         }
     }
+
+    public function testExist()
+    {
+        // "decade1980" could be confused for an hash because it's 10 hexa-decimal characters
+        $filename = 'decade1980/pangram.txt';
+        $content = 'The quick brown fox jumps over a lazy dog';
+        $hash = sha1($content);
+        $store = $this->getBackend();
+
+        // File haven't been created yet
+        $this->assertFalse($store->exists($filename, $hash));
+        $this->assertFalse($store->exists($filename, $hash, 'variant'));
+
+        // Create main file on protected store
+        $store->setFromString($content, $filename);
+        $this->assertTrue($store->exists($filename, $hash));
+        $this->assertFalse($store->exists($filename, $hash, 'variant'));
+
+        // Create variant on protected store
+        $store->setFromString(strtoupper($content), $filename, $hash, 'variant');
+        $this->assertTrue($store->exists($filename, $hash, 'variant'));
+
+        // Publish file to public store
+        $store->publish($filename, $hash);
+        $this->assertTrue($store->exists($filename, $hash));
+        $this->assertTrue($store->exists($filename, $hash, 'variant'));
+
+        // Files should be gone
+        $store->delete($filename, $hash);
+        $this->assertFalse($store->exists($filename, $hash));
+        $this->assertFalse($store->exists($filename, $hash, 'variant'));
+    }
 }


### PR DESCRIPTION
`FileIDHelperResolutionStrategy::stripVariant()` would think that hexadecimal folder where hash.

# Parent Issue
* #300 