### PR TITLE
Allow the temporary store for intervention to be configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-sudo: false
+dist: xenial
+
+services:
+  - mysql
+  - postgresql
 
 env:
   global:

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -65,6 +65,11 @@ class InterventionBackend implements Image_Backend, Flushable
     const FAILED_UNKNOWN = 'unknown';
 
     /**
+     * @config - used to set where cached intervention files will be stored
+     */
+    private static $local_temp_path = TEMP_PATH;
+
+    /**
      * @var AssetContainer
      */
     private $container;
@@ -240,7 +245,8 @@ class InterventionBackend implements Image_Backend, Flushable
         try {
             // write the file to a local path so we can extract exif data if it exists.
             // Currently exif data can only be read from file paths and not streams
-            $path = tempnam(TEMP_PATH, 'interventionimage_');
+            $tempPath = $this->config()->get('local_temp_path') ?? TEMP_PATH;
+            $path = tempnam($tempPath, 'interventionimage_');
             if ($extension = pathinfo($assetContainer->getFilename(), PATHINFO_EXTENSION)) {
                 //tmpnam creates a file, we should clean it up if we are changing the path name
                 unlink($path);

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -65,7 +65,10 @@ class InterventionBackend implements Image_Backend, Flushable
     const FAILED_UNKNOWN = 'unknown';
 
     /**
-     * @config - used to set where cached intervention files will be stored
+     * Configure where cached intervention files will be stored
+     *
+     * @config
+     * @var string
      */
     private static $local_temp_path = TEMP_PATH;
 


### PR DESCRIPTION
The goal for this is to allow devs to configure if they want to use `TEMP_PATH` or another location. 

The idea here being that when you're dealing with a large amount of assets on a small disk you can run out of space quickly which can be elevated by using a different path