### PR TITLE
Allow the temporary store for intervention to be configured

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -65,6 +65,14 @@ class InterventionBackend implements Image_Backend, Flushable
     const FAILED_UNKNOWN = 'unknown';
 
     /**
+     * Configure where cached intervention files will be stored
+     *
+     * @config
+     * @var string
+     */
+    private static $local_temp_path = TEMP_PATH;
+
+    /**
      * @var AssetContainer
      */
     private $container;
@@ -240,7 +248,8 @@ class InterventionBackend implements Image_Backend, Flushable
         try {
             // write the file to a local path so we can extract exif data if it exists.
             // Currently exif data can only be read from file paths and not streams
-            $path = tempnam(TEMP_PATH, 'interventionimage_');
+            $tempPath = $this->getTempPathConfig();
+            $path = tempnam($tempPath, 'interventionimage_');
             if ($extension = pathinfo($assetContainer->getFilename(), PATHINFO_EXTENSION)) {
                 //tmpnam creates a file, we should clean it up if we are changing the path name
                 unlink($path);
@@ -834,5 +843,15 @@ class InterventionBackend implements Image_Backend, Flushable
         // Ensure stream is readable
         $meta = stream_get_meta_data($stream);
         return isset($meta['mode']) && (strstr($meta['mode'], 'r') || strstr($meta['mode'], '+'));
+    }
+
+    /**
+     * This gets the temp path config usually set through local_temp_path
+     *
+     * @return string
+     */
+    public function getTempPathConfig(): string
+    {
+        return $this->config()->get('local_temp_path') ?? TEMP_PATH;
     }
 }

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -70,7 +70,7 @@ class InterventionBackend implements Image_Backend, Flushable
      * @config
      * @var string
      */
-    private static $local_temp_path = TEMP_PATH;
+    private static $local_temp_path;
 
     /**
      * @var AssetContainer

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -852,6 +852,6 @@ class InterventionBackend implements Image_Backend, Flushable
      */
     public function getTempPathConfig(): string
     {
-        return $this->config()->get('local_temp_path') ?? TEMP_PATH;
+        return (string) $this->config()->get('local_temp_path') ?? TEMP_PATH;
     }
 }


### PR DESCRIPTION
Could we also back port this to v 1.3.3 and onwards if possible (constrained by being stuck on certain prior versions due to recipes)?

This uhhh, is basically this but a bit better... https://github.com/silverstripe/silverstripe-assets/pull/306

Reason being is that on certain envs you won't know the path of the temp dir until you have code running and for perf you might not want to set it each time through _config.php