### PR TITLE
Handle SS3.0 file ID variant

### DIFF
--- a/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
+++ b/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
@@ -185,7 +185,7 @@ class LegacyThumbnailMigrationHelper
             $moved[$oldResampledPath] = $newResampledPath;
         }
 
-        // Remove folder and any subfolders. If one or more thumbnail didn't
+        // Remove folder and any subfolders. If one or more thumbnails didn't
         // get migrated leave the folder where it is.
         if (!$foundError) {
             $filesystem->deleteDir($resampledFolderPath);

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -41,7 +41,8 @@ class LegacyFileIDHelper implements FileIDHelper
         'paddedimage',
         'formattedimage',
         'resizedimage',
-        'croppedimage'
+        'croppedimage',
+        'cropheight',
     ];
 
     /** @var bool */

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -137,7 +137,7 @@ class LegacyFileIDHelper implements FileIDHelper
 
     /**
      * Try to parse a FileID as a pre-SS33 variant. From SS3.0 to SS3.2 the variants were prefixed in the file name,
-     * rather than ecoded into folders.
+     * rather than encoded into folders.
      * @param string $fileID Variant file ID. Variantless FileID should have been parsed by `parseFileID`.
      * @return ParsedFileID|null
      */
@@ -157,7 +157,7 @@ class LegacyFileIDHelper implements FileIDHelper
             return null;
         }
 
-        // Our SS3 variant can be confused with regular filename, let's minise the risk of this by making
+        // Our SS3 variant can be confused with regular filenames, let's minimise the risk of this by making
         // sure all our variants use a valid SS3 variant expression
         $variant = trim($matches['variant'], '-');
         $possibleVariants = explode('-', $variant);
@@ -169,8 +169,8 @@ class LegacyFileIDHelper implements FileIDHelper
             // Find the base64 encoded argument attached to the image method
             if (preg_match($validVariantRegex, $possible, $variantMatches)) {
                 try {
-                    // Our base 64 encoded string always decodes to an string representation of php array
-                    // So we're assuming it always start with a `[` and ends with a `]`
+                    // Our base 64 encoded string always decodes to a string representation of php array
+                    // So we're assuming it always starts with a `[` and ends with a `]`
                     $base64Str = $variantMatches['base64'];
                     $argumentString = base64_decode($base64Str);
                     if ($argumentString && preg_match('/^\[.*\]$/', $argumentString)) {

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Assets\FilenameParsing;
 
+use Exception;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 
 /**
@@ -15,6 +17,32 @@ use SilverStripe\Core\Injector\Injectable;
 class LegacyFileIDHelper implements FileIDHelper
 {
     use Injectable;
+    use Configurable;
+
+    /**
+     * List of SilverStripe 3 image method names that can appear in variants. Prior to SilverStripe 3.3, variants were
+     * incoded in the filename with dashes. e.g.: `_resampled/FitW10-sam.jpg` rather than `_resampled/FitW10/sam.jpg`.
+     * @config
+     */
+    private static $ss3_image_variant_methods = [
+        'fit',
+        'fill',
+        'pad',
+        'scalewidth',
+        'scaleheight',
+        'setratiosize',
+        'setwidth',
+        'setheight',
+        'setsize',
+        'cmsthumbnail',
+        'assetlibrarypreview',
+        'assetlibrarythumbnail',
+        'stripthumbnail',
+        'paddedimage',
+        'formattedimage',
+        'resizedimage',
+        'croppedimage'
+    ];
 
     /** @var bool */
     private $failNewerVariant;
@@ -82,15 +110,19 @@ class LegacyFileIDHelper implements FileIDHelper
     public function parseFileID($fileID)
     {
         if ($this->failNewerVariant) {
-            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>([^.]+))/)?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#';
+            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>([^.]+))/)?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#i';
         } else {
-            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>([^.]+))/)?((?<basename>([^/.])+))(?<extension>(\..+)*)$#';
+            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>([^.]+))/)?((?<basename>([^/.])+))(?<extension>(\..+)*)$#i';
         }
-
 
         // not a valid file (or not a part of the filesystem)
         if (!preg_match($pattern, $fileID, $matches)) {
             return null;
+        }
+
+        // Can't have a resampled folder without a variant
+        if (empty($matches['variant']) && strpos($fileID, '_resampled') !== false) {
+            return $this->parseSilverStripe30VariantFileID($fileID);
         }
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
@@ -100,6 +132,90 @@ class LegacyFileIDHelper implements FileIDHelper
             isset($matches['variant']) ? str_replace('/', '_', $matches['variant']) : '',
             $fileID
         );
+    }
+
+    /**
+     * Try to parse a FileID as a pre-SS33 variant. From SS3.0 to SS3.2 the variants were prefixed in the file name,
+     * rather than ecoded into folders.
+     * @param string $fileID Variant file ID. Variantless FileID should have been parsed by `parseFileID`.
+     * @return ParsedFileID|null
+     */
+    private function parseSilverStripe30VariantFileID($fileID)
+    {
+        $ss3Methods = $this->getImageVariantMethods();
+        $variantPartialRegex = implode('|', $ss3Methods);
+
+        if ($this->failNewerVariant) {
+            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>((((' . $variantPartialRegex . ')[^.-]+))-)+))?((?<basename>((?<!__)[^/.])+))(?<extension>(\..+)*)$#i';
+        } else {
+            $pattern = '#^(?<folder>([^/]+/)*?)(_resampled/(?<variant>((((' . $variantPartialRegex . ')[^.-]+))-)+))?((?<basename>([^/.])+))(?<extension>(\..+)*)$#i';
+        }
+
+        // not a valid file (or not a part of the filesystem)
+        if (!preg_match($pattern, $fileID, $matches)) {
+            return null;
+        }
+
+        // Our SS3 variant can be confused with regular filename, let's minise the risk of this by making
+        // sure all our variants use a valid SS3 variant expression
+        $variant = trim($matches['variant'], '-');
+        $possibleVariants = explode('-', $variant);
+        $validVariants = [];
+        $validVariantRegex = '#^(' . $variantPartialRegex . ')(?<base64>(.+))$#i';
+
+        // Loop through the possible variants until we find an invalid one
+        while ($possible = array_shift($possibleVariants)) {
+            // Find the base64 encoded argument attached to the image method
+            if (preg_match($validVariantRegex, $possible, $variantMatches)) {
+                try {
+                    // Our base 64 encoded string always decodes to an string representation of php array
+                    // So we're assuming it always start with a `[` and ends with a `]`
+                    $base64Str = $variantMatches['base64'];
+                    $argumentString = base64_decode($base64Str);
+                    if ($argumentString && preg_match('/^\[.*\]$/', $argumentString)) {
+                        $validVariants[] = $possible;
+                        continue;
+                    }
+                } catch (Exception $ex) {
+                    // If we get an error in the regex or in the base64 decode, assume our possible variant is invalid.
+                }
+            }
+            array_unshift($possibleVariants, $possible);
+            break;
+        }
+
+
+        // Can't have a resampled folder without a variant
+        if (empty($validVariants)) {
+            return null;
+        }
+
+        // Reconcatenate our variants
+        $variant = implode('_', $validVariants);
+
+        // Our invalid variants are part of the filename
+        $invalidVariant = $possibleVariants ? implode('-', $possibleVariants) . '-' : '';
+        $filename = $matches['folder'] . $invalidVariant . $matches['basename'] . $matches['extension'];
+
+        return new ParsedFileID($filename, '', $variant, $fileID);
+    }
+
+
+    /**
+     * Get a list of possible variant methods.
+     * @return string[]
+     */
+    private function getImageVariantMethods()
+    {
+        $variantMethods = self::config()->get('ss3_image_variant_methods');
+        // Sort the variant methods by descending order of string length.
+        // This is important because the regex will match the string in order of appearance.
+        // e.g. `paddedimageW10` could be confused for `pad` with a base64 string of `dedimageW10`
+        usort($variantMethods, function ($a, $b) {
+            return strlen($b) - strlen($a);
+        });
+
+        return $variantMethods;
     }
 
     public function isVariantOf($fileID, ParsedFileID $original)

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -84,6 +84,10 @@ class FileMigrationHelperTest extends SapphireTest
             $fs->write($dir . '/_resampled/resizeXYZ/' . $basename, $fromVariant);
             rewind($fromVariant);
             $fs->write($dir . '/_resampled/resizeXYZ/scaleABC/' . $basename, $fromVariant);
+            rewind($fromVariant);
+            $fs->write($dir . '/_resampled/ScaleWidthWzEwMF0-' . $basename, $fromVariant);
+            rewind($fromVariant);
+            $fs->write($dir . '/_resampled/ScaleWidthWzEwMF0-FitWzEwMCwxMDBd-' . $basename, $fromVariant);
         }
         fclose($fromMain);
         fclose($fromVariant);
@@ -275,17 +279,23 @@ class FileMigrationHelperTest extends SapphireTest
     private function individualImage(Image $file)
     {
         // Test that our image variant got moved correctly
-        $filename = TestAssetStore::base_path() . '/' . $file->getFilename();
-        $dir = dirname($filename);
-        $filename = basename($filename);
+        $fullFilename = TestAssetStore::base_path() . '/' . $file->getFilename();
+        $dir = dirname($fullFilename);
+        $baseFilename = basename($fullFilename);
         $this->assertFileNotExists($dir . '/_resampled');
-        $this->assertFileExists($dir . '/' . $filename);
+        $this->assertFileExists($dir . '/' . $baseFilename);
 
-        $filename = preg_replace('#^(.*)\.(.*)$#', '$1__resizeXYZ.$2', $filename);
-        $this->assertFileExists($dir . '/' . $filename);
+        // Test that SS3.3 variants have been migrated
+        $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1__resizeXYZ.$2', $baseFilename);
+        $this->assertFileExists($dir . '/' . $variantFilename);
+        $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1_scaleABC.$2', $variantFilename);
+        $this->assertFileExists($dir . '/' . $variantFilename);
 
-        $filename = preg_replace('#^(.*)\.(.*)$#', '$1_scaleABC.$2', $filename);
-        $this->assertFileExists($dir . '/' . $filename);
+        // Test that pre SS3.3 variants have been migrated
+        $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1__ScaleWidthWzEwMF0.$2', $baseFilename);
+        $this->assertFileExists($dir . '/' . $variantFilename);
+        $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1_FitWzEwMCwxMDBd.$2', $variantFilename);
+        $this->assertFileExists($dir . '/' . $variantFilename);
     }
 
     /**

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -291,7 +291,7 @@ class FileMigrationHelperTest extends SapphireTest
         $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1_scaleABC.$2', $variantFilename);
         $this->assertFileExists($dir . '/' . $variantFilename);
 
-        // Test that pre SS3.3 variants have been migrated
+        // Test that pre SS3.0 variants have been migrated
         $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1__ScaleWidthWzEwMF0.$2', $baseFilename);
         $this->assertFileExists($dir . '/' . $variantFilename);
         $variantFilename = preg_replace('#^(.*)\.(.*)$#', '$1_FitWzEwMCwxMDBd.$2', $variantFilename);

--- a/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
@@ -15,6 +15,10 @@ use SilverStripe\Dev\SapphireTest;
 
 class LegacyThumbnailMigrationHelperTest extends SapphireTest
 {
+    const CORE_VERSION_3_0_0 = '300';
+
+    const CORE_VERSION_3_3_0 = '330';
+
     protected $usesTransactions = false;
 
     protected static $fixture_file = 'LegacyThumbnailMigrationHelperTest.yml';
@@ -64,7 +68,10 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
         parent::tearDown();
     }
 
-    public function testMigratesWithExistingThumbnailInNewLocation()
+    /**
+     * @dataProvider coreVersionsProvider
+     */
+    public function testMigratesWithExistingThumbnailInNewLocation($coreVersion)
     {
         /** @var TestAssetStore $store */
         $store = singleton(AssetStore::class); // will use TestAssetStore
@@ -74,7 +81,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
 
         $formats = ['ResizedImage' => [60,60]];
         $expectedNewPath = $this->getNewResampledPath($image, $formats, $keep = true);
-        $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats);
+        $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats, $coreVersion);
 
         $helper = new LegacyThumbnailMigrationHelper();
         $moved = $helper->run($store);
@@ -93,7 +100,10 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
         );
     }
 
-    public function testMigratesMultipleFilesInSameFolder()
+    /**
+     * @dataProvider coreVersionsProvider
+     */
+    public function testMigratesMultipleFilesInSameFolder($coreVersion)
     {
         /** @var TestAssetStore $store */
         $store = singleton(AssetStore::class); // will use TestAssetStore
@@ -109,7 +119,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
         $formats = ['ResizedImage' => [60,60]];
         foreach ($images as $image) {
             $expectedNewPath = $this->getNewResampledPath($image, $formats);
-            $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats);
+            $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats, $coreVersion);
             $expected[$expectedLegacyPath] = $expectedNewPath;
         }
 
@@ -185,29 +195,63 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
     public function dataProvider()
     {
         return [
-            'Single variant toplevel' => [
+            'Single variant toplevel 3.0.0' => [
                 'toplevel',
-                ['ResizedImage' => [60,60]]
+                ['ResizedImage' => [60,60]],
+                self::CORE_VERSION_3_0_0
             ],
-            'Multi variant toplevel' => [
+            'Single variant toplevel >=3.3.0' => [
                 'toplevel',
-                ['ResizedImage' => [60,60], 'CropHeight' => [30]]
+                ['ResizedImage' => [60,60]],
+                self::CORE_VERSION_3_3_0
             ],
-            'Multi variant nested' => [
+            'Multi variant toplevel 3.0.0' => [
+                'toplevel',
+                ['ResizedImage' => [60,60], 'CropHeight' => [30]],
+                self::CORE_VERSION_3_0_0
+            ],
+            'Multi variant toplevel >=3.3.0' => [
+                'toplevel',
+                ['ResizedImage' => [60,60], 'CropHeight' => [30]],
+                self::CORE_VERSION_3_3_0
+            ],
+            'Multi variant nested 3.0.0' => [
                 'nested',
-                ['ResizedImage' => [60,60], 'CropHeight' => [30]]
+                ['ResizedImage' => [60,60], 'CropHeight' => [30]],
+                self::CORE_VERSION_3_0_0
+            ],
+            'Multi variant nested >=3.3.0' => [
+                'nested',
+                ['ResizedImage' => [60,60], 'CropHeight' => [30]],
+                self::CORE_VERSION_3_3_0
             ]
         ];
     }
 
+    public function coreVersionsProvider()
+    {
+        return [
+            '3.0.0' => [self::CORE_VERSION_3_0_0],
+//            '3.3.0' => [self::CORE_VERSION_3_3_0]
+        ];
+    }
+
     /**
+     * @param AssetStore $store
      * @param Image $baseImage
-     * @param array
+     * @param array $formats
+     * @param string $coreVersion
      * @return string Path relative to the asset store root.
      */
-    protected function createLegacyResampledImageFixture(AssetStore $store, Image $baseImage, $formats)
+    protected function createLegacyResampledImageFixture(AssetStore $store, Image $baseImage, $formats, $coreVersion)
     {
-        $resampledRelativePath = $this->legacyCacheFilename($baseImage, $formats);
+        if ($coreVersion == self::CORE_VERSION_3_0_0) {
+            $resampledRelativePath = $this->legacyCacheFilenameVersion300($baseImage, $formats);
+        } elseif($coreVersion == self::CORE_VERSION_3_3_0) {
+            $resampledRelativePath = $this->legacyCacheFilenameVersion330($baseImage, $formats);
+        } else {
+            throw new \Exception('Invalid $coreVersion');
+        }
 
         // Using raw copy operation since File->copyFile() messes with the _resampled path nane,
         // and anything on asset abstraction unhelpfully copies
@@ -227,13 +271,18 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
     }
 
     /**
-     * Replicates the logic of creating 3.x style formatted images,
+     * Replicates the logic of creating >=3.3 style formatted images,
      * based on Image->cacheFilename() and Image->generateFormattedImage().
      * Will create folder structures required for this.
+     * This naming placed files with their original name
+     * into a subfolder named after the manipulation.
+     *
+     * Format: <base-folder>/_resampled/<format1>/<format2>/<filename>
+     * Example: my-folder/_resampled/ResizedImageWzYwMCwyMDld/ScaleHeightWyIxMDAiXQ/image.jpg
      *
      * @return string Path relative to the asset store root.
      */
-    protected function legacyCacheFilename($image, $formats)
+    protected function legacyCacheFilenameVersion330($image, $formats)
     {
         $cacheFilename = '';
 
@@ -253,6 +302,40 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
         $cacheFilename = $this->joinPaths(
             $cacheFilename,
             basename($image->generateFilename())
+        );
+
+        return $cacheFilename;
+    }
+
+    /**
+     * Replicates the logic of creating <3.3 style formatted images,
+     * based on Image->cacheFilename() and Image->generateFormattedImage().
+     * Will create folder structures required for this.
+     * This naming used composite filenames with their formats.
+     *
+     * Format: <base-folder>/_resampled/<format1>-<format2>-<filename>
+     * Example: my-folder/_resampled/ResizedImageWzYwMCwyMDld-ScaleHeightWyIxMDAiXQ-image.jpg
+     *
+     * @return string Path relative to the asset store root.
+     */
+    protected function legacyCacheFilenameVersion300($image, $formats)
+    {
+        $cacheFilename = '';
+
+        if ($image->Parent()->exists()) {
+            $cacheFilename = $image->Parent()->Filename;
+        }
+
+        $cacheFilename = $this->joinPaths($cacheFilename, '_resampled');
+
+        $formatPrefix = '';
+        foreach ($formats as $format => $args) {
+            $formatPrefix .= $format . Convert::base64url_encode($args) . '-';
+        }
+
+        $cacheFilename = $this->joinPaths(
+            $cacheFilename,
+            $formatPrefix . basename($image->generateFilename())
         );
 
         return $cacheFilename;

--- a/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
@@ -146,7 +146,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
     /**
      * @dataProvider dataProvider
      */
-    public function testMigrate($fixtureId, $formats)
+    public function testMigrate($fixtureId, $formats, $coreVersion)
     {
         /** @var TestAssetStore $store */
         $store = singleton(AssetStore::class); // will use TestAssetStore
@@ -158,7 +158,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
         // Important to do this *before* creating the legacy file,
         // because the LegacyFileIDHelper will pick it up as the "new" location otherwise
         $expectedNewPath = $this->getNewResampledPath($image, $formats);
-        $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats);
+        $expectedLegacyPath = $this->createLegacyResampledImageFixture($store, $image, $formats, $coreVersion);
 
         $helper = new LegacyThumbnailMigrationHelper();
         $moved = $helper->run($store);
@@ -232,7 +232,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
     {
         return [
             '3.0.0' => [self::CORE_VERSION_3_0_0],
-//            '3.3.0' => [self::CORE_VERSION_3_3_0]
+            '3.3.0' => [self::CORE_VERSION_3_3_0]
         ];
     }
 
@@ -247,7 +247,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
     {
         if ($coreVersion == self::CORE_VERSION_3_0_0) {
             $resampledRelativePath = $this->legacyCacheFilenameVersion300($baseImage, $formats);
-        } elseif($coreVersion == self::CORE_VERSION_3_3_0) {
+        } elseif ($coreVersion == self::CORE_VERSION_3_3_0) {
             $resampledRelativePath = $this->legacyCacheFilenameVersion330($baseImage, $formats);
         } else {
             throw new \Exception('Invalid $coreVersion');

--- a/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.php
+++ b/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.php
@@ -286,13 +286,13 @@ class TagsToShortcodeHelperTest extends SapphireTest
                 '<a href="assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg">link to file</a>',
                 sprintf('<a href="[file_link,id=%d]">link to file</a>', $image1ID)
             ],
+             'link to image SS3.0 variant' => [
+                '<a href="assets/_resampled/ResizedImageWzY0LDY0XQ-myimage.jpg">link to file</a>',
+                sprintf('<a href="[file_link,id=%d]">link to file</a>', $image1ID)
+             ],
             'link to hash url' => [
                 '<a href="assets/0ba2141b89/document.pdf">link to file</a>',
                 sprintf('<a href="[file_link,id=%d]">link to file</a>', $documentID)
-            ],
-            'link to hash url variant' => [
-                '<a href="assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg">link to file</a>',
-                sprintf('<a href="[file_link,id=%d]">link to file</a>', $image1ID)
             ],
             'link without closing tag' => [
                 '<a href="assets/document.pdf">Link to file',
@@ -314,6 +314,9 @@ class TagsToShortcodeHelperTest extends SapphireTest
             ],
             'image variant' => [
                 '<img src="assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg">',
+                sprintf('[image src="/assets/33be1b95cb/myimage.jpg" id="%d"]', $image1ID)],
+            'image SS3.0 variant' => [
+                '<img src="assets/_resampled/ResizedImageWzY0LDY0XQ-myimage.jpg">',
                 sprintf('[image src="/assets/33be1b95cb/myimage.jpg" id="%d"]', $image1ID)],
             'image variant with size' => [
                 '<img src="assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg" width="100" height="133">',

--- a/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
@@ -28,6 +28,9 @@ class NaturalFileIDHelperTest extends FileIDHelperTester
             ['subfolder/under_score/sam_single-underscore__resizeXYZ.jpg', [
                 'subfolder/under_score/sam_single-underscore.jpg', '', 'resizeXYZ'
             ]],
+            ['subfolder/under_score/sam_single-underscore__resizeXYZ_scaleheightABC.jpg', [
+                'subfolder/under_score/sam_single-underscore.jpg', '', 'resizeXYZ_scaleheightABC'
+            ]],
             ['subfolder/under_score/sam_double_dots.tar.gz', [
                 'subfolder/under_score/sam_double_dots.tar.gz', ''
             ]],
@@ -58,6 +61,9 @@ class NaturalFileIDHelperTest extends FileIDHelperTester
             ['subfolder/sam_double-under-score__resizeXYZ.jpg', [
                 'subfolder/sam__double-under-score.jpg', '', 'resizeXYZ'
             ]],
+            ['subfolder/sam_double-under-score__resizeXYZ_scaleheightABC.jpg', [
+                'subfolder/sam__double-under-score.jpg', '', 'resizeXYZ_scaleheightABC'
+            ]],
             ['sam_double-under-score__resizeXYZ.jpg', [
                 'sam__double-under-score.jpg', 'abcdef7890', 'resizeXYZ'
             ]],
@@ -84,6 +90,9 @@ class NaturalFileIDHelperTest extends FileIDHelperTester
             ]],
             ['subfolder/sam__double-under-score__resizeXYZ.jpg', [
                 'subfolder/sam__double-under-score.jpg', 'abcdef7890', 'resizeXYZ'
+            ]],
+            ['subfolder/sam__double-under-score__resizeXYZ_scaleheightABC.jpg', [
+                'subfolder/sam__double-under-score.jpg', 'abcdef7890', 'resizeXYZ_scaleheightABC'
             ]],
         ];
     }

--- a/tests/php/RedirectFileControllerTest.php
+++ b/tests/php/RedirectFileControllerTest.php
@@ -414,6 +414,15 @@ class RedirectFileControllerTest extends FunctionalTest
             'SS3 Legacy path to variant should redirect.'
         );
 
+        $response = $this->get("/assets/{$foldername}_resampled/$suffix-$filename.$ext");
+        $this->assertResponse(
+            301,
+            '',
+            $icoUrl,
+            $response,
+            'SS3.0 Legacy path to variant should redirect.'
+        );
+
         $file->setFromLocalFile(__DIR__ . '/ImageTest/test-image-high-quality.jpg', $file->FileFilename);
         $file->write();
         $file->publishSingle();


### PR DESCRIPTION
SS3.0 variants had their variant code prefix stored in the file name. That got changed in SS3.3 to have them in folders.

All our migration logic was assuming the SS3.3 kind of variant. This PR:
* Updates LegacyFileIDHelper to understand SS3.0 variant FileID
* Updates LegacyThumbnailMigrationHelper to use FileIDHelpers to parse FileIDs
  * All classes that us FileIDHelpers to understand SS3 variants should magically start working.
* Update unit test to try ss3.0 variant for the following cases:
  * Migrating Legacy thumbnail
  * Migrating SS3 files
  * Redirect old variant URL
  * Convert Tags to short code.

# Note
I didn't actually test any of those cases for "real". It's all unit tests magic.

I'll do an actual test now, but you can start the peer review.


# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/313