### PR TITLE
FIX Do not try to migrate field on all their subclasses

### DIFF
--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -380,7 +380,8 @@ class TagsToShortcodeHelper
             /** @var DataObjectSchema $schema */
             $schema = singleton($class)->getSchema();
             /** @var DataObject $fields */
-            $fields = $schema->fieldSpecs($class);
+            $fields = $schema->fieldSpecs($class, DataObjectSchema::DB_ONLY|DataObjectSchema::UNINHERITED);
+
             foreach ($fields as $field => $type) {
                 $type = preg_replace('/\(.*\)$/', '', $type);
                 if (in_array($type, $fieldNames)) {


### PR DESCRIPTION
We trying to migrate fields on its parent table and all the matching sub classes.

# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/316