### PR TITLE
BUG Update regex matching tags to stop looking after the closing > char

### DIFF
--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -210,7 +210,8 @@ class TagsToShortcodeHelper
     {
         $resultTags = [];
 
-        preg_match_all('/<('.$this->validTagsPattern.').*?('.$this->validAttributesPattern.')\s*=.*?>/i', $content, $matches, PREG_SET_ORDER);
+        $regex = '/<('.$this->validTagsPattern.')\s[^>]*?('.$this->validAttributesPattern.')\s*=.*?>/i';
+        preg_match_all($regex, $content, $matches, PREG_SET_ORDER);
         if ($matches) {
             foreach ($matches as $match) {
                 $resultTags []= $match[0];
@@ -313,7 +314,6 @@ class TagsToShortcodeHelper
                     '/href\s*=\s*(?:"|\').*?(?:"|\')/i',
                     '/id\s*=\s*(?:"|\').*?(?:"|\')/i',
                     '/\s*(\/?>|\])/',
-                    '/\s?\S+=("")|(\'\')/'
                 ];
                 $replace = [
                     '[image',
@@ -321,12 +321,11 @@ class TagsToShortcodeHelper
                     "href=\"/".ASSETS_DIR."/{$parsedFileID->getFileID()}\"",
                     "",
                     " id=\"{$file->ID}\"]",
-                    "",
                 ];
                 $shortcode = preg_replace($find, $replace, $tag);
             } elseif ($tagType == 'a') {
                 $attribute = 'href';
-                $find= "/$attribute\s*=\s*(?:\"|').*?(?:\"|')/i";
+                $find = "/$attribute\s*=\s*(?:\"|').*?(?:\"|')/i";
                 $replace = "$attribute=\"[file_link,id={$file->ID}]\"";
                 $shortcode = preg_replace($find, $replace, $tag);
             } else {

--- a/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.php
+++ b/tests/php/Dev/Tasks/TagsToShortcodeHelperTest.php
@@ -327,7 +327,7 @@ class TagsToShortcodeHelperTest extends SapphireTest
             ],
             'empty attribute image' => [
                 '<img src="assets/myimage.jpg" title="">',
-                sprintf('[image src="/assets/33be1b95cb/myimage.jpg" id="%d"]', $image1ID)
+                sprintf('[image src="/assets/33be1b95cb/myimage.jpg" title="" id="%d"]', $image1ID)
             ],
             'image caption' => [
                 '<div class="captionImage leftAlone" style="width: 100px;"><img class="leftAlone" src="assets/myimage.jpg" alt="sam" width="100" height="133"><p class="caption leftAlone">My caption</p></div>',
@@ -354,6 +354,13 @@ class TagsToShortcodeHelperTest extends SapphireTest
             'image with underscore' => [
                 '<img src="assets/decade1980/under_score.jpg">',
                 sprintf('[image src="/assets/decade1980/33be1b95cb/under_score.jpg" id="%d"]', $underscoreFile)
+            ],
+            'image inside a tag without href' => [
+                '<p><a><img src="assets/_resampled/ResizedImageWzY0LDY0XQ/myimage.jpg" class="leftAlone" title="" alt="" width="600" height="400"></a></p>',
+                sprintf(
+                    '<p><a>[image src="/assets/33be1b95cb/myimage.jpg" class="leftAlone" title="" alt="" width="600" height="400" id="%d"]</a></p>',
+                    $image1ID
+                )
             ],
         ];
     }


### PR DESCRIPTION
There's a regex that's meant to find the opening `<a>` and `<img>` tags. However, it wouldn't stopping looking after coming across a `>` character.

So when looking at an expression like this `<a><img src="my-image.jpg"></a>`, `<a><img src="my-image.jpg">` would be match as the opening tag.

# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/320