### PR TITLE
BUG Delete the published variant before the publishing the draft version

### DIFF
--- a/src/AssetControlExtension.php
+++ b/src/AssetControlExtension.php
@@ -138,10 +138,10 @@ class AssetControlExtension extends DataExtension
             // Archived assets are kept protected
             $this->protectAll($deletedAssets);
         } else {
+            // Remove old version
+            $this->deleteAll($deletedAssets);
             // Publish assets
             $this->publishAll($manipulations->getPublicAssets());
-            // Otherwise remove all assets
-            $this->deleteAll($deletedAssets);
         }
 
         // Protect assets


### PR DESCRIPTION
When we publish a variant, the draft version and all its variants get copied over to the public store, then the existing files get deleted. 

In most cases, this worked fine if your draft version had the same variants as the published file, because the draft files/variants would override the published ones.

However, if your draft store doesn't contain all the variants the live store does, when the main file gets copied over, the AssetStore will start reading the hash of the main file. This is probablematic, because variants of the original file will confused for variants of the newly published file and won't be deleted.

By deleting the published files first, we prevent this weird condition.

# Parent issue
* https://github.com/silverstripe/silverstripe-asset-admin/issues/970