### PR TITLE
FIX: Chained image manipulations had unexpected behaviour (fixes #332)

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -947,7 +947,7 @@ trait ImageManipulation
                 $tuple = $result;
                 Deprecation::notice(
                     '5.0',
-                    'Closure passed to ImageManipulation::manipulate() should return null or a two-item array 
+                    'Closure passed to ImageManipulation::manipulate() should return null or a two-item array
                         containing a tuple and an image backend, i.e. [$tuple, $result]',
                     Deprecation::SCOPE_GLOBAL
                 );
@@ -971,10 +971,11 @@ trait ImageManipulation
         /** @var DBFile $file */
         $file = DBField::create_field('DBFile', $tuple);
 
-        // Pass the manipulated image backend down to the resampled image - this allows chained manipulations
-        // without having to re-load the image resource from the manipulated file written to disk
-        if ($manipulationResult instanceof Image_Backend) {
-            $file->setImageBackend($manipulationResult);
+        // Preserve the current image quality setting, so chained manipulations like
+        // $Quality(1).SetWidth(500) work as expected
+        $currentBackend = $this->getImageBackend();
+        if (method_exists($currentBackend, 'getQuality')) {
+            $file->getImageBackend()->setQuality($currentBackend->getQuality());
         }
 
         return $file->setOriginal($this);

--- a/tests/php/ImageTest.php
+++ b/tests/php/ImageTest.php
@@ -114,16 +114,30 @@ abstract class ImageTest extends SapphireTest
 
         $imageFirst = $image->ScaleWidth(200);
         $this->assertNotNull($imageFirst);
-        $expected = 200;
-        $actual = $imageFirst->getWidth();
-
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals(200, $imageFirst->getWidth());
 
         $imageSecond = $imageFirst->ScaleHeight(100);
         $this->assertNotNull($imageSecond);
-        $expected = 100;
-        $actual = $imageSecond->getHeight();
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals(100, $imageSecond->getHeight());
+
+        // Manipulate a pre-manipulated image twice...
+        // ... this tests that one manipulation on a pre-manipulated image
+        // doesn't affect subsequent manipulations from the same source image
+        $image = $this->objFromFixture(Image::class, 'imageWithoutTitle');
+        $squareImage = $image->Fill(500, 500);
+        $this->assertNotNull($squareImage);
+        $this->assertEquals(500, $squareImage->getWidth());
+        $this->assertEquals(500, $squareImage->getHeight());
+
+        $smallSquareImage = $squareImage->ScaleMaxWidth(200);
+        $this->assertNotNull($smallSquareImage);
+        $this->assertEquals(200, $smallSquareImage->getWidth());
+        $this->assertEquals(200, $smallSquareImage->getHeight());
+
+        $extraSmallSquareImage = $squareImage->ScaleMaxWidth(50);
+        $this->assertNotNull($extraSmallSquareImage);
+        $this->assertEquals(50, $extraSmallSquareImage->getWidth());
+        $this->assertEquals(50, $extraSmallSquareImage->getHeight());
     }
 
     /**


### PR DESCRIPTION
Just to explain the patch, given `$Image.Quality(10).Fill(500, 500)`:

Current code:
1. Image resource is loaded
2. Image is resampled to low-quality and written to disk
3. Image resource is passed down to the resampled `DBFile` that’s returned
4. `Fill(500, 500)` is then called on the existing backend + resource, which still has the quality setting stored

The problem with the current code is that in the event that the image resource is garbage collected before another manipulation takes place with the same `Image` record, instead of re-loading the image resource from the resampled copy to work with it’ll load it from the original image. That happens because the `Image_Backend` instance that is currently passed down to the resampled copy has the original `DBFile` tuple stored.

Another problem with the current code that this change fixes is the following example:

```php
// Works as expected
$image->Quality(1)->Fill(200, 200);
// Loads the “Quality1” resampled image created above from the disk, but then saves the
// 500x500 version out with a quality setting of 100, resulting in a large file size
$image->Quality(1)->Fill(500, 500);
```

## Parent issue
- #332 