### PR TITLE
Use a timestamp in the hash cache

### DIFF
--- a/src/Dev/Tasks/VersionedFilesMigrationTask.php
+++ b/src/Dev/Tasks/VersionedFilesMigrationTask.php
@@ -29,5 +29,4 @@ class VersionedFilesMigrationTask extends BuildTask
         $migrator = VersionedFilesMigrator::create($strategy, ASSETS_PATH, true);
         $migrator->migrate();
     }
-
 }

--- a/src/Dev/VersionedFilesMigrator.php
+++ b/src/Dev/VersionedFilesMigrator.php
@@ -191,5 +191,4 @@ class VersionedFilesMigrator
     {
         return $this->log;
     }
-
 }

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -45,7 +45,7 @@ class Sha1FileHashingService implements FileHashingService, Flushable
 
     /** @var Filesystem[] */
     private $filesystems;
-    
+
     public function computeFromStream($stream)
     {
         Util::rewindStream($stream);
@@ -120,7 +120,7 @@ class Sha1FileHashingService implements FileHashingService, Flushable
         $fs = $this->getFilesystem($fs);
         $stream = $fs->readStream($fileID);
         $hash = $this->computeFromStream($stream);
-        
+
         $this->set($fileID, $fs, $hash);
 
         return $hash;
@@ -178,9 +178,12 @@ class Sha1FileHashingService implements FileHashingService, Flushable
      */
     private function buildCacheKey($fileID, $fs)
     {
-        $fsID = $this->getFilesystemKey($fs);
+        $filesystem = $this->getFilesystem($fs);
 
-        return base64_encode(sprintf('%s://%s', $fsID, $fileID));
+        $fsID = $this->getFilesystemKey($fs);
+        $timestamp = $filesystem->getTimestamp($fileID);
+
+        return base64_encode(sprintf('%s://%s://%s', $fsID, $fileID, $timestamp));
     }
 
     public function invalidate($fileID, $fs)

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -181,7 +181,10 @@ class Sha1FileHashingService implements FileHashingService, Flushable
         $filesystem = $this->getFilesystem($fs);
 
         $fsID = $this->getFilesystemKey($fs);
-        $timestamp = $filesystem->getTimestamp($fileID);
+
+        $timestamp = $filesystem->has($fileID) ?
+            $filesystem->getTimestamp($fileID) :
+            null;
 
         return base64_encode(sprintf('%s://%s://%s', $fsID, $fileID, $timestamp));
     }

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -182,9 +182,13 @@ class Sha1FileHashingService implements FileHashingService, Flushable
 
         $fsID = $this->getFilesystemKey($fs);
 
-        $timestamp = $filesystem->has($fileID) ?
-            $filesystem->getTimestamp($fileID) :
-            null;
+        try {
+            $timestamp = $filesystem->has($fileID) ?
+                $filesystem->getTimestamp($fileID) :
+                null;
+        } catch (FileNotFoundException $e) {
+            $timestamp = null;
+        }
 
         return base64_encode(sprintf('%s://%s://%s', $fsID, $fileID, $timestamp));
     }

--- a/tests/php/Flysystem/FlysystemAssetStoreTest.php
+++ b/tests/php/Flysystem/FlysystemAssetStoreTest.php
@@ -50,7 +50,7 @@ class FlysystemAssetStoreTest extends SapphireTest
             ->getMock();
 
         $this->publicFilesystem = $this->getMockBuilder(Filesystem::class)
-            ->setMethods(['has', 'read', 'readStream'])
+            ->setMethods(['has', 'read', 'readStream', 'getTimestamp'])
             ->setConstructorArgs([$this->publicAdapter])
             ->getMock();
 
@@ -59,7 +59,7 @@ class FlysystemAssetStoreTest extends SapphireTest
             ->getMock();
 
         $this->protectedFilesystem = $this->getMockBuilder(Filesystem::class)
-            ->setMethods(['has', 'read', 'readStream'])
+            ->setMethods(['has', 'read', 'readStream', 'getTimestamp'])
             ->setConstructorArgs([$this->protectedAdapter])
             ->getMock();
 

--- a/tests/php/Storage/Sha1FileHashingServiceTest.php
+++ b/tests/php/Storage/Sha1FileHashingServiceTest.php
@@ -54,6 +54,7 @@ class Sha1FileHashingServiceTest extends SapphireTest
 
         $this->publicFs->write($this->fileID, $this->publicContent);
         $this->protectedFs->write($this->fileID, $this->protectedContent);
+        Sha1FileHashingService::flush();
     }
 
     public function tearDown()

--- a/tests/php/Storage/Sha1FileHashingServiceTest.php
+++ b/tests/php/Storage/Sha1FileHashingServiceTest.php
@@ -78,7 +78,7 @@ class Sha1FileHashingServiceTest extends SapphireTest
         }
     }
 
-    public function testcomputeFromFile()
+    public function testComputeFromFile()
     {
         $service = new Sha1FileHashingService();
         $service->disableCache();
@@ -135,6 +135,25 @@ class Sha1FileHashingServiceTest extends SapphireTest
         $hash = sha1('missing-file.text');
         $service->set('missing-file.text', AssetStore::VISIBILITY_PUBLIC, $hash);
         $this->assertEquals($hash, $service->computeFromFile('missing-file.text', AssetStore::VISIBILITY_PUBLIC));
+    }
+
+    public function testComputeTouchFile()
+    {
+        $service = new Sha1FileHashingService();
+        $service->enableCache();
+
+        $this->assertEquals($this->publicHash, $service->computeFromFile($this->fileID, $this->publicFs));
+
+        // Our timestamp is accruate to the second, we need to wait a bit to make sure our new timestamp won't be in
+        // the same second as the old one.
+        sleep(2);
+        $this->publicFs->update($this->fileID, $this->protectedContent);
+
+        $this->assertEquals(
+            $this->protectedHash,
+            $service->computeFromFile($this->fileID, $this->publicFs),
+            'When a file is touched by an outside process, existing value for that file are invalidated'
+        );
     }
 
     public function testCompare()


### PR DESCRIPTION
Caching between two servers is not working as expected. This address that.

Checks to see if File exists before proceeding
https://github.com/silverstripe/silverstripe-assets/blob/1/src/Storage/DBFile.php#L365 
Uses "Flysystem" to check for file existing
https://github.com/silverstripe/silverstripe-assets/blob/master/src/Flysystem/FlysystemAssetStore.php#L1231 
Compares "Hashes" of what is in the database, and what is returned by Flysystem (If they do not match, which they dont, it skips)
https://github.com/silverstripe/silverstripe-assets/blob/master/src/Flysystem/FlysystemAssetStore.php#L327 
Flysystem checks if Cached value of Hash exists (which it does) and returns the cached value instead of checking directly.
https://github.com/silverstripe/silverstripe-assets/blob/master/src/Storage/Sha1FileHashingService.php#L116

This is the point in which a different Hash value is returned by Cache on the offending server (as the cache has not been invalidated / cleared on the server which did not receive the upload).

Cache is non-memory based and is set to infinite lifecycle (meaning it won't expire unless it is specifically removed).
https://github.com/silverstripe/silverstripe-assets/blob/master/_config/assetscache.yml#L17 

By default, all SilverStripe caches are stored in the TempDir (/tmp/silverstripe...). This directory is not shared between servers, so each individual web server contains its own cache values

# Parent issue
* #336