### PR TITLE
FIX Force alt attribute to render, remove fallback to image Title

### DIFF
--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -84,18 +84,18 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
 
         // Build the HTML tag
         $attrs = array_merge(
-            // Set overrideable defaults
-            ['src' => '', 'alt' => $record->Title],
+            // Set overrideable defaults ('alt' must be present regardless of contents)
+            ['src' => '', 'alt' => ''],
             // Use all other shortcode arguments
             $args,
             // But enforce some values
             ['id' => '', 'src' => $src]
         );
 
-        // Clean out any empty attributes
-        $attrs = array_filter($attrs, function ($v) {
-            return (bool)$v;
-        });
+        // Clean out any empty attributes (aside from alt)
+        $attrs = array_filter($attrs, function ($k, $v) {
+            return (bool)$v || $k === 'alt';
+        }, ARRAY_FILTER_USE_BOTH);
 
         $markup = HTML::createTag('img', $attrs);
 

--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -94,7 +94,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
 
         // Clean out any empty attributes (aside from alt)
         $attrs = array_filter($attrs, function ($k, $v) {
-            return (bool)$v || $k === 'alt';
+            return strlen(trim($v)) || $k === 'alt';
         }, ARRAY_FILTER_USE_BOTH);
 
         $markup = HTML::createTag('img', $attrs);

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -43,7 +43,7 @@ class ImageShortcodeProviderTest extends SapphireTest
         parent::tearDown();
     }
 
-    public function testShortcodeHandlerFallsBackToFileProperties()
+    public function testShortcodeHandlerDoesNotFallBackToFileProperties()
     {
         $image = $this->objFromFixture(Image::class, 'imageWithTitle');
         $parser = new ShortcodeParser();
@@ -51,7 +51,7 @@ class ImageShortcodeProviderTest extends SapphireTest
 
         $this->assertEquals(
             sprintf(
-                '<img src="%s" alt="This is a image Title">',
+                '<img src="%s" alt="">',
                 $image->Link()
             ),
             $parser->parse(sprintf('[image id=%d]', $image->ID))
@@ -84,7 +84,7 @@ class ImageShortcodeProviderTest extends SapphireTest
 
         $this->assertEquals(
             sprintf(
-                '<img src="%s" alt="test image">',
+                '<img src="%s" alt="">',
                 $image->Link()
             ),
             $parser->parse(sprintf(
@@ -104,7 +104,7 @@ class ImageShortcodeProviderTest extends SapphireTest
             $nonExistentImageID++;
         }
         $this->assertEquals(
-            '<img alt="Image not found">',
+            '<img alt="">',
             $parser->parse(sprintf(
                 '[image id="%d"]',
                 $nonExistentImageID


### PR DESCRIPTION
Some images are presentational, and therefore shouldn't have alt content. Others have captions, and therefore the alt content would be duplicate. Most importantly, the name of a file often doesn't accurately or sufficiently describe its contents, and so it is unfit as alt content.

To improve a11y, the alt attribute should always be rendered, even if it's empty, and it should not have a default value.

Part of [asset-admin#983](https://github.com/silverstripe/silverstripe-asset-admin/issues/983).

Also resolves https://github.com/silverstripe/silverstripe-assets/issues/129