### PR TITLE
FIX Do not show FileLink's in campaigns

### DIFF
--- a/src/Shortcodes/FileLink.php
+++ b/src/Shortcodes/FileLink.php
@@ -27,4 +27,12 @@ class FileLink extends DataObject
         'Parent' => DataObject::class,
         'Linked' => File::class,
     ];
+
+    /**
+     * Don't show this model in campaign admin as part of implicit change sets
+     *
+     * @config
+     * @var bool
+     */
+    private static $hide_in_campaigns = true;
 }


### PR DESCRIPTION
Relates to https://github.com/silverstripe/silverstripe-asset-admin/issues/903