### PR TITLE
BUGFIX handle files with no extension as if they are invalid

### DIFF
--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -96,7 +96,7 @@ class FileMigrationHelper
         Environment::increaseTimeLimitTo();
         Environment::setMemoryLimitMax(-1);
         Environment::increaseMemoryLimitTo(-1);
-        
+
         /** @var FileHashingService $hasher */
         $hasher = Injector::inst()->get(FileHashingService::class);
         $hasher::flush();
@@ -319,7 +319,7 @@ class FileMigrationHelper
         } catch (ValidationException $e) {
             if ($this->logger) {
                 $this->logger->error(sprintf(
-                    "File %s could not be migrated due to an error. 
+                    "File %s could not be migrated due to an error.
                     This problem likely existed before the migration began. Error: %s",
                     $legacyFilename,
                     $e->getMessage()
@@ -368,7 +368,7 @@ class FileMigrationHelper
         $legacyFilenameGlob = preg_replace_callback('/[a-z]/i', function ($matches) {
             return sprintf('[%s%s]', strtolower($matches[0]), strtoupper($matches[0]));
         }, $strippedLegacyFilename);
-        
+
         $files = glob($base . DIRECTORY_SEPARATOR . ASSETS_DIR . DIRECTORY_SEPARATOR . $legacyFilenameGlob);
 
         switch (sizeof($files)) {
@@ -569,7 +569,7 @@ class FileMigrationHelper
      *
      * return void
      */
-    protected function handleInvalidFile($file, $messages, $legacyFilename)
+    private function handleInvalidFile($file, $messages, $legacyFilename)
     {
         if ($this->config()->get('delete_invalid_files')) {
             $file->delete();

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -257,8 +257,14 @@ class FileMigrationHelper
             return false;
         }
 
-        // Fix file classname if it has a classname that's incompatible with its extention
+        // Ignore extensionless files
         $extension = $file->getExtension();
+        if ($extension === '') {
+            $this->handleInvalidFile($file, [['message' => 'Files without an extension can not be migrated']], $legacyFilename);
+            return false;
+        }
+
+        // Fix file classname if it has a classname that's incompatible with its extension
         if (!$this->validateFileClassname($file, $extension)) {
             // We disable validation (if it is enabled) so that we are able to write a corrected
             // classname, once that is changed we re-enable it for subsequent writes
@@ -278,21 +284,7 @@ class FileMigrationHelper
         // Remove invalid files
         $validationResult = $file->validate();
         if (!$validationResult->isValid()) {
-            if ($this->config()->get('delete_invalid_files')) {
-                $file->delete();
-            }
-            if ($this->logger) {
-                $messages = implode("\n\n", array_map(function ($msg) {
-                    return $msg['message'];
-                }, $validationResult->getMessages()));
-                $this->logger->warning(
-                    sprintf(
-                        "  %s was not migrated because the file is not valid. More information: %s",
-                        $legacyFilename,
-                        $messages
-                    )
-                );
-            }
+            $this->handleInvalidFile($file, $validationResult->getMessages(), $legacyFilename);
             return false;
         }
 
@@ -568,5 +560,31 @@ class FileMigrationHelper
             ->selectFromTable($table, ['ID', 'Filename'])
             ->execute()
             ->map(); // map ID to Filename
+    }
+
+    /**
+     * @param File $file
+     * @param array $messages
+     * @param string $legacyFilename
+     *
+     * return void
+     */
+    protected function handleInvalidFile($file, $messages, $legacyFilename)
+    {
+        if ($this->config()->get('delete_invalid_files')) {
+            $file->delete();
+        }
+        if ($this->logger) {
+            $logMessages = implode("\n\n", array_map(function ($msg) {
+                return $msg['message'];
+            }, $messages));
+            $this->logger->warning(
+                sprintf(
+                    "  %s was not migrated because the file is not valid. More information: %s",
+                    $legacyFilename,
+                    $logMessages
+                )
+            );
+        }
     }
 }

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -178,8 +178,8 @@ class FileMigrationHelperTest extends SapphireTest
     {
         $this->preCondition();
 
-        // The EXE file and missing file won't be migrated
-        $expectNumberOfMigratedFiles = File::get()->exclude('ClassName', Folder::class)->count() - 3;
+        // The EXE file, extensionless file and missing file won't be migrated
+        $expectNumberOfMigratedFiles = File::get()->exclude('ClassName', Folder::class)->count() - 4;
 
         // Do migration
         $helper = new FileMigrationHelper();
@@ -208,6 +208,7 @@ class FileMigrationHelperTest extends SapphireTest
         }
 
         $this->invalidFile();
+        $this->fileWithNoExtension();
         $this->pdfNormalisedToFile();
         $this->badSS3filenames();
         $this->conflictualBadNames();
@@ -304,6 +305,15 @@ class FileMigrationHelperTest extends SapphireTest
     private function invalidFile()
     {
         $invalidID = $this->idFromFixture(File::class, 'invalid');
+        $this->assertNotEmpty($invalidID);
+        $this->assertNull(File::get()->byID($invalidID));
+    }
+    /**
+     * Ensure that invalid file has been removed during migration. One file without an extension should have been removed from the DB
+     */
+    private function fileWithNoExtension()
+    {
+        $invalidID = $this->idFromFixture(File::class, 'no-extension');
         $this->assertNotEmpty($invalidID);
         $this->assertNull(File::get()->byID($invalidID));
     }

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.yml
@@ -44,6 +44,10 @@ SilverStripe\Assets\File:
   invalid:
     Name: myfile.exe
     ParentID: =>SilverStripe\Assets\Folder.subfolder
+  # Files with no extension are not allowed
+  no-extension:
+    Name: myfile
+    ParentID: =>SilverStripe\Assets\Folder.subfolder
   # badnameconflict will want to override goodnameconflict
   goodnameconflict:
     Name: bad_name.doc


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/9037

Struggling to get the tests to run locally but I've added one in, hopefully Travis can determine that this works.

Aims to gracefully skip over a file if it has no extension rather than implode the task.