### PR TITLE
Only cache shortcode if file was found

### DIFF
--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -89,8 +89,10 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
         }
 
         // Find appropriate record, with fallback for error handlers
+        $fileFound = true;
         $record = static::find_shortcode_record($arguments, $errorCode);
         if ($errorCode) {
+            $fileFound = false;
             $record = static::find_error_record($errorCode);
         }
         if (!$record) {
@@ -114,11 +116,13 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
         }
 
         // cache it for future reference
-        $cache->set($cacheKey, [
-            'markup' => $markup,
-            'filename' => $record instanceof File ? $record->getFilename() : null,
-            'hash' => $record instanceof File ? $record->getHash() : null,
-        ]);
+        if ($fileFound) {
+            $cache->set($cacheKey, [
+                'markup' => $markup,
+                'filename' => $record instanceof File ? $record->getFilename() : null,
+                'hash' => $record instanceof File ? $record->getHash() : null,
+            ]);
+        }
 
         return $markup;
     }

--- a/tests/php/Shortcodes/FileShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/FileShortcodeProviderTest.php
@@ -103,4 +103,37 @@ class FileShortcodeProviderTest extends SapphireTest
             $this->assertEquals('', $parser->parse($fileEnclosed));
         }
     }
+
+    public function testMissingFileDoesNotCache()
+    {
+        $parser = new ShortcodeParser();
+        $parser->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);
+
+        $nonExistentFileID = $this->getNonExistentFileID();
+        $shortcode = '[file_link id="' . $nonExistentFileID . '"]';
+
+        // make sure cache is not populated from a previous test
+        $cache = FileShortcodeProvider::getCache();
+        $cache->clear();
+
+        $args = ['id' => (string) $nonExistentFileID];
+        $cacheKey = FileShortcodeProvider::getCacheKey($args, "");
+
+        // assert that cache is empty before parsing shortcode
+        $this->assertTrue(is_null($cache->get($cacheKey)));
+
+        $parser->parse($shortcode);
+
+        // assert that cache is still empty after parsing shortcode
+        $this->assertTrue(is_null($cache->get($cacheKey)));
+    }
+
+    private function getNonExistentFileID()
+    {
+        $nonExistentFileID = 9999;
+        while (Image::get()->byID($nonExistentFileID)) {
+            $nonExistentFileID++;
+        }
+        return $nonExistentFileID;
+    }
 }

--- a/tests/php/Shortcodes/FileShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/FileShortcodeProviderTest.php
@@ -109,7 +109,7 @@ class FileShortcodeProviderTest extends SapphireTest
         $parser = new ShortcodeParser();
         $parser->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);
 
-        $nonExistentFileID = $this->getNonExistentFileID();
+        $nonExistentFileID = File::get()->max('ID') + 1;
         $shortcode = '[file_link id="' . $nonExistentFileID . '"]';
 
         // make sure cache is not populated from a previous test
@@ -120,20 +120,11 @@ class FileShortcodeProviderTest extends SapphireTest
         $cacheKey = FileShortcodeProvider::getCacheKey($args, "");
 
         // assert that cache is empty before parsing shortcode
-        $this->assertTrue(is_null($cache->get($cacheKey)));
+        $this->assertNull($cache->get($cacheKey));
 
         $parser->parse($shortcode);
 
         // assert that cache is still empty after parsing shortcode
-        $this->assertTrue(is_null($cache->get($cacheKey)));
-    }
-
-    private function getNonExistentFileID()
-    {
-        $nonExistentFileID = 9999;
-        while (Image::get()->byID($nonExistentFileID)) {
-            $nonExistentFileID++;
-        }
-        return $nonExistentFileID;
+        $this->assertNull($cache->get($cacheKey));
     }
 }

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -99,7 +99,7 @@ class ImageShortcodeProviderTest extends SapphireTest
         $parser = new ShortcodeParser();
         $parser->register('image', [ImageShortcodeProvider::class, 'handle_shortcode']);
 
-        $nonExistentImageID = $this->getNonExistentImageID();
+        $nonExistentImageID = File::get()->max('ID') + 1;
         $expected = '<img alt="Image not found">';
         $shortcodes = [
             '[image id="' . $nonExistentImageID . '"]',
@@ -117,7 +117,7 @@ class ImageShortcodeProviderTest extends SapphireTest
         $parser = new ShortcodeParser();
         $parser->register('image', [ImageShortcodeProvider::class, 'handle_shortcode']);
 
-        $nonExistentImageID = $this->getNonExistentImageID();
+        $nonExistentImageID = File::get()->max('ID') + 1;;
         $shortcode = '[image id="' . $nonExistentImageID . '"]';
 
         // make sure cache is not populated from a previous test
@@ -128,20 +128,11 @@ class ImageShortcodeProviderTest extends SapphireTest
         $cacheKey = ImageShortcodeProvider::getCacheKey($args);
 
         // assert that cache is empty before parsing shortcode
-        $this->assertTrue(is_null($cache->get($cacheKey)));
+        $this->assertNull($cache->get($cacheKey));
 
         $parser->parse($shortcode);
 
         // assert that cache is still empty after parsing shortcode
-        $this->assertTrue(is_null($cache->get($cacheKey)));
-    }
-
-    private function getNonExistentImageID()
-    {
-        $nonExistentImageID = 9999;
-        while (Image::get()->byID($nonExistentImageID)) {
-            $nonExistentImageID++;
-        }
-        return $nonExistentImageID;
+        $this->assertNull($cache->get($cacheKey));
     }
 }

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -3,13 +3,8 @@
 namespace SilverStripe\Assets\Tests\Shortcodes;
 
 use SilverStripe\Assets\File;
-use SilverStripe\Assets\Filesystem;
-use SilverStripe\Assets\Folder;
 use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ErrorPage\ErrorPage;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\ShortcodeParser;
 use SilverStripe\Assets\Image;
 use SilverStripe\Assets\Shortcodes\ImageShortcodeProvider;
@@ -118,7 +113,7 @@ class ImageShortcodeProviderTest extends SapphireTest
         $parser = new ShortcodeParser();
         $parser->register('image', [ImageShortcodeProvider::class, 'handle_shortcode']);
 
-        $nonExistentImageID = File::get()->max('ID') + 1;;
+        $nonExistentImageID = File::get()->max('ID') + 1;
         $shortcode = '[image id="' . $nonExistentImageID . '"]';
 
         // make sure cache is not populated from a previous test

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -19,6 +19,7 @@ use SilverStripe\Assets\Shortcodes\ImageShortcodeProvider;
  */
 class ImageShortcodeProviderTest extends SapphireTest
 {
+
     protected static $fixture_file = '../ImageTest.yml';
 
     public function setUp()
@@ -124,7 +125,7 @@ class ImageShortcodeProviderTest extends SapphireTest
         $cache = ImageShortcodeProvider::getCache();
         $cache->clear();
 
-        $args = ['id' => (string) $nonExistentImageID];
+        $args = ['id' => (string)$nonExistentImageID];
         $cacheKey = ImageShortcodeProvider::getCacheKey($args);
 
         // assert that cache is empty before parsing shortcode

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -144,5 +144,4 @@ class ImageShortcodeProviderTest extends SapphireTest
         }
         return $nonExistentImageID;
     }
-
 }


### PR DESCRIPTION
Shortcode classes for image and file_link will cache the generated results even if the file was not found.  This can cause issues on multi-server environments where file replication may be lagging behind i.e. the cached result is "file not found", even though the file is now present on the server

Also fixed a secondary issue with image shortcodes where the alt tag did not say "Image not found" if another alt tag was specified, which makes it harder to diagnose what's going on when an image is actually missing