### PR TITLE
add config setting + task for flushing IntervetionBackend cache

### DIFF
--- a/src/Dev/Tasks/InterventionBackendCacheFlushTask.php
+++ b/src/Dev/Tasks/InterventionBackendCacheFlushTask.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\Assets\Dev\Tasks;
+
+use SilverStripe\Assets\InterventionBackend;
+use SilverStripe\Dev\BuildTask;
+
+/**
+ * A task to manually flush InterventionBackend cache
+ */
+class InterventionBackendCacheFlushTask extends BuildTask
+{
+    private static $segment = 'InterventionBackendCacheFlushTask';
+
+    protected $title = 'Clear InterventionBackend cache';
+
+    protected $description = "Clears caches for InterventionBackend";
+
+    /**
+     * @param \SilverStripe\Control\HTTPRequest $request
+     * @throws \ReflectionException
+     */
+    public function run($request)
+    {
+        $class = new InterventionBackend();
+        $class->getCache()->clear();
+
+        echo 'DONE';
+    }
+}

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -19,6 +19,7 @@ use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Config\Config;
 
 class InterventionBackend implements Image_Backend, Flushable
 {
@@ -33,6 +34,14 @@ class InterventionBackend implements Image_Backend, Flushable
      * Cache prefix for dimensions
      */
     const CACHE_DIMENSIONS = 'DIMENSIONS_';
+
+    /**
+     * Is cache flushing enabled?
+     *
+     * @config
+     * @var boolean
+     */
+    private static $flush_enabled = true;
 
     /**
      * How long to cache each error type
@@ -812,9 +821,11 @@ class InterventionBackend implements Image_Backend, Flushable
      */
     public static function flush()
     {
-        /** @var CacheInterface $cache */
-        $cache = Injector::inst()->get(CacheInterface::class . '.InterventionBackend_Manipulations');
-        $cache->clear();
+        if (Config::inst()->get(static::class, 'flush_enabled')) {
+            /** @var CacheInterface $cache */
+            $cache = Injector::inst()->get(CacheInterface::class . '.InterventionBackend_Manipulations');
+            $cache->clear();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/issues/197 when config is set to false. I have left the default value as true to match the previous behavior allowing users to opt-in to these caches not being cleared.

Was also tempted to change `$cache = Injector::inst()->get(CacheInterface::class . '.InterventionBackend_Manipulations');` to `$cache = (new static())->getCache();` - if you want that including in, or a seperate PR let me know.