### PR TITLE
Folder won't find or make in archived mode

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -68,6 +68,12 @@ class Folder extends File
                 'Name' => array($partSafe, $part)
             ))->first();
 
+            // In archived mode we would expect for folders to sometimes not exist and therefore shouldn't create them
+            if (class_exists(Versioned::class)
+                && strpos(Versioned::get_reading_mode(), 'Archive.') !== false) {
+                return null;
+            }
+
             if (!$item) {
                 $item = new Folder();
                 $item->ParentID = $parentID;


### PR DESCRIPTION
We had this issue where the folder was made later than the version of the page we were looking at which meant each time you viewed the archived page a new folder would be made as it wouldn't exist at that time

Should solve: https://github.com/silverstripe/silverstripe-assets/issues/330
