### PR TITLE
FIX temp images not being deleted if error is thrown

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -284,6 +284,9 @@ class InterventionBackend implements Image_Backend, Flushable
             if ($error) {
                 $this->markFailed($hash, $variant, $error);
             }
+            if (isset($path) && file_exists($path)) {
+                unlink($path);
+            }
         }
         return null;
     }


### PR DESCRIPTION
When images are being manipulated it creates a temp file from the stream in the `silverstripe-cache` folder. these images doesn't get deleted and stays in the cache folders. I've noticed this when using every version of the assets module.

Based on https://github.com/silverstripe/silverstripe-assets/pull/351