### PR TITLE
BUG Update FileIDHelpers to replace backslashes with forward slashes

### DIFF
--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -73,6 +73,9 @@ class HashFileIDHelper implements FileIDHelper
 
     public function cleanFilename($filename)
     {
+        // Swap backslash for forward slash
+        $filename = str_replace('\\', '/', $filename);
+
         // Since we use double underscore to delimit variants, eradicate them from filename
         return preg_replace('/_{2,}/', '_', $filename);
     }

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -97,6 +97,9 @@ class LegacyFileIDHelper implements FileIDHelper
 
     public function cleanFilename($filename)
     {
+        // Swap backslash for forward slash
+        $filename = str_replace('\\', '/', $filename);
+
         // There's not really any relevant cleaning rule for legacy. It's not important any way because we won't be
         // generating legacy URLs, aside from maybe for testing.
         return $filename;

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -63,10 +63,13 @@ class NaturalFileIDHelper implements FileIDHelper
 
     public function cleanFilename($filename)
     {
+        // Swap backslash for forward slash
+        $filename = str_replace('\\', '/', $filename);
+
         // Since we use double underscore to delimit variants, eradicate them from filename
         return preg_replace('/_{2,}/', '_', $filename);
     }
-    
+
     public function parseFileID($fileID)
     {
         $pattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';

--- a/tests/php/FilenameParsing/HashFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/HashFileIDHelperTest.php
@@ -83,6 +83,7 @@ class HashFileIDHelperTest extends FileIDHelperTester
             ['sub_folder/double_underscore.jpg', 'sub_folder/double__underscore.jpg'],
             ['sub_folder/single_underscore.jpg', 'sub_folder/single_underscore.jpg'],
             ['sub_folder/triple_underscore.jpg', 'sub_folder/triple___underscore.jpg'],
+            ['Folder/With/Backslash/file.jpg', 'Folder\With\Backslash\file.jpg'],
         ];
     }
 

--- a/tests/php/FilenameParsing/LegacyFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/LegacyFileIDHelperTest.php
@@ -83,6 +83,7 @@ class LegacyFileIDHelperTest extends FileIDHelperTester
             ['sub_folder/sam.jpg', 'sub_folder/sam.jpg'],
             ['sub_folder/double__underscore.jpg', 'sub_folder/double__underscore.jpg'],
             ['sub_folder/single_underscore.jpg', 'sub_folder/single_underscore.jpg'],
+            ['Folder/With/Backslash/file.jpg', 'Folder\With\Backslash\file.jpg'],
         ];
     }
 

--- a/tests/php/FilenameParsing/MigrationLegacyFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/MigrationLegacyFileIDHelperTest.php
@@ -80,6 +80,7 @@ class MigrationLegacyFileIDHelperTest extends FileIDHelperTester
             ['sub_folder/sam.jpg', 'sub_folder/sam.jpg'],
             ['sub_folder/double__underscore.jpg', 'sub_folder/double__underscore.jpg'],
             ['sub_folder/single_underscore.jpg', 'sub_folder/single_underscore.jpg'],
+            ['Folder/With/Backslash/file.jpg', 'Folder\With\Backslash\file.jpg'],
         ];
     }
 

--- a/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
@@ -106,6 +106,7 @@ class NaturalFileIDHelperTest extends FileIDHelperTester
             ['sub_folder/double_underscore.jpg', 'sub_folder/double__underscore.jpg'],
             ['sub_folder/single_underscore.jpg', 'sub_folder/single_underscore.jpg'],
             ['sub_folder/triple_underscore.jpg', 'sub_folder/triple___underscore.jpg'],
+            ['Folder/With/Backslash/file.jpg', 'Folder\With\Backslash\file.jpg'],
         ];
     }
 


### PR DESCRIPTION
This simple fix simply updates the file ID to replace backslashes with forward slashes.

The point of this is to fix an issue where if you set the content of a file with backslashes in the filename, you end up with folders inside the hash folder.

# Parent issue
* https://github.com/silverstripe/silverstripe-assets/issues/380
