### PR TITLE
Cache DBFile::exists() and reduce calls to file_exists()

### DIFF
--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -321,7 +321,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
                 if ($parsedFileID->getHash()) {
                     $mainFileID = $strategy->buildFileID($strategy->stripVariant($parsedFileID));
 
-                    if (!$fs->has($mainFileID)) {
+                    if ($mainFileID !== $fileID && !$fs->has($mainFileID)) {
                         // The main file doesn't exists ... this is kind of weird.
                         continue;
                     }

--- a/src/Services/ReadOnlyCacheService.php
+++ b/src/Services/ReadOnlyCacheService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SilverStripe\Assets\Services;
+
+use SilverStripe\Core\Injector\Injectable;
+
+/**
+ * Used to cache results for the duration of a request during read-only file operations
+ * Do not use this during any create, update or delete operations
+ */
+class ReadOnlyCacheService
+{
+
+    use Injectable;
+
+    private $enabled = false;
+
+    private $cache = [];
+
+    public function getEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function reset(?array $cacheNameComponents = null): void
+    {
+        if (is_null($cacheNameComponents)) {
+            $this->cache = [];
+            return;
+        }
+        $cacheName = $this->buildKey($cacheNameComponents);
+        if (isset($this->cache[$cacheName])) {
+            unset($this->cache[$cacheName]);
+        }
+    }
+
+    public function setValue(array $cacheNameComponents, array $cacheKeyComponents, $value): void
+    {
+        $cacheName = $this->buildKey($cacheNameComponents);
+        $key = $this->buildKey($cacheKeyComponents);
+        if (!isset($this->cache[$cacheName])) {
+            $this->cache[$cacheName] = [];
+        }
+        $this->cache[$cacheName][$key] = $value;
+    }
+
+    public function getValue(array $cacheNameComponents, array $cacheKeyComponents)
+    {
+        $cacheName = $this->buildKey($cacheNameComponents);
+        $key = $this->buildKey($cacheKeyComponents);
+        return $this->cache[$cacheName][$key] ?? null;
+    }
+
+    public function hasValue(array $cacheNameComponents, array $cacheKeyComponents): bool
+    {
+        $cacheName = $this->buildKey($cacheNameComponents);
+        $key = $this->buildKey($cacheKeyComponents);
+        return isset($this->cache[$cacheName]);
+    }
+
+    private function buildKey(array $components)
+    {
+        return implode('-', $components);
+    }
+}

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Assets\Storage;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\ImageManipulation;
+use SilverStripe\Assets\Services\ReadOnlyCacheService;
 use SilverStripe\Assets\Thumbnail;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
@@ -359,12 +360,22 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
 
     public function exists()
     {
+        $cacheService = ReadOnlyCacheService::singleton();
+        $cacheNameComponents = [__CLASS__, __FUNCTION__];
+        $dbFileComponents = [$this->Filename, $this->Hash, $this->Variant];
+        if ($cacheService->getEnabled() && $cacheService->hasValue($cacheNameComponents, $dbFileComponents)) {
+            return $cacheService->getValue($cacheNameComponents, $dbFileComponents);
+        }
         if (empty($this->Filename)) {
             return false;
         }
-        return $this
+        $exists = $this
             ->getStore()
             ->exists($this->Filename, $this->Hash, $this->Variant);
+        if ($cacheService->getEnabled()) {
+            $cacheService->setValue($cacheNameComponents, $dbFileComponents, $exists);
+        }
+        return $exists;
     }
 
     public function getFilename()

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Assets\Storage;
 use InvalidArgumentException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Util;
+use League\Flysystem\FileNotFoundException;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Flushable;
@@ -189,10 +190,20 @@ class Sha1FileHashingService implements FileHashingService, Flushable
      */
     private function getTimestamp($fileID, $fs)
     {
+        $timestamp = '';
         $filesystem = $this->getFilesystem($fs);
-        return $filesystem->has($fileID) ?
-            $filesystem->getTimestamp($fileID) :
-            DBDatetime::now()->getTimestamp();
+        // Using a try/catch block instead of Filesystem::has() because that's already
+        // called in Filesystem::assertPresent()
+        try {
+            // Filesystem::getTimestamp($path) will get a timestamp of the physical file
+            // if it fails for whatever reason, then it will either
+            // a) return false, or
+            // b) throw a FileNotFoundException from Filesystem::assertPresent()
+            $timestamp = $filesystem->getTimestamp($fileID);
+        } catch (FileNotFoundException $exception) {
+            // do nothing
+        }
+        return $timestamp ?: DBDatetime::now()->getTimestamp();
     }
 
     public function invalidate($fileID, $fs)

--- a/tests/php/Services/ReadOnlyCacheServiceTest.php
+++ b/tests/php/Services/ReadOnlyCacheServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\Services;
+
+use SilverStripe\Assets\Services\ReadOnlyCacheService;
+use SilverStripe\Dev\SapphireTest;
+
+class ReadOnlyCacheServiceTest extends SapphireTest
+{
+
+    public function testGetSetEnabled()
+    {
+        $service = ReadOnlyCacheService::singleton();
+        $this->assertFalse($service->getEnabled());
+        $service->setEnabled(true);
+        $this->assertTrue($service->getEnabled());
+    }
+
+    public function testGetSetHasValue()
+    {
+        $service = ReadOnlyCacheService::singleton();
+        $this->assertFalse($service->hasValue(['A', 'B'], ['1', '2']));
+        $service->setValue(['A', 'B'], ['1', '2'], 'xyz');
+        $this->assertTrue($service->hasValue(['A', 'B'], ['1', '2']));
+        $this->assertEquals('xyz', $service->getValue(['A', 'B'], ['1', '2']));
+    }
+
+    public function testReset()
+    {
+        $service = ReadOnlyCacheService::singleton();
+        $service->setValue(['A', 'B'], ['1', '2'], 'xyz');
+        $service->setValue(['C', 'D'], ['3', '4'], 'wvu');
+        $this->assertTrue($service->hasValue(['A', 'B'], ['1', '2']));
+        $service->reset(['A', 'B']);
+        $this->assertFalse($service->hasValue(['A', 'B'], ['1', '2']));
+        $this->assertTrue($service->hasValue(['C', 'D'], ['3', '4']));
+        $service->reset();
+        $this->assertFalse($service->hasValue(['C', 'D'], ['3', '4']));
+    }
+}


### PR DESCRIPTION
Performance improvements, primarily to the the file manager section in the CMS

Profiled using xhprof when viewing the gallery view in the file manager.  There is an excessively large number of calls to file_exists() due to excessive rechecking during graphql requests

This pull request contains:
- add some caching to DBFile::exists()
- prevent a possible duplicate check to FlysystemAssetStore::applyToFileOnFilesystem()
- prevent a double check in Sha1FileHashingService::getTimestamp()

Note: the branch name includes `1.5` though it was later rebased off `1` since this requires a minor release as it adds new API

### Related PRs
Related PR asset-admin: silverstripe/silverstripe-asset-admin#1078 

### Travis cwp-recipie-kitchen-sink integration testing
https://travis-ci.org/github/creative-commoners/cwp-recipe-kitchen-sink/builds/675232333

### Profiling results

FileManager gallery view - 50 files - 49 draft and 1 published

The way the asset abstraction works, the public store gets checked first and if that's not found the protected store gets the gets checked. Because most of the files are in the protected store, this is pretty much a worst case scenario.

The same file is checked for existence many times repeatedly, it's not very optimised.  Variants are such as thumbnails are checked for existence separately from the main file.

This was done on a vagrant setup so it'll be much slower than a proper server

Times are measure in xhprof using Incl. Wall Time (microsec) - which is the total time spent in the function and all child functions.  100,000 microsec = 100 milliseconds

DBFile::exists() - 306 Calls

baseline
331,094
322,158
413,078

pull request
146,256
104,318
103,692

Calls to League\Flysystem\Adapter\Local::has - this is the main function that calls file_exists()

baseline - 4,019 calls
66,568
69,775
76,692

pull request - 1,634 calls
35,296
32,674
35,566
