### PR TITLE
Update debug message wording as moved files are not always thumbnails

### DIFF
--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -348,7 +348,7 @@ class FileMigrationHelper
 
         if (!empty($results['Operations'])) {
             foreach ($results['Operations'] as $origin => $destination) {
-                $this->logger->debug(sprintf('  related thumbnail %s moved to %s', $origin, $destination));
+                $this->logger->debug(sprintf('  related file %s moved to %s', $origin, $destination));
             }
         }
 
@@ -480,7 +480,7 @@ class FileMigrationHelper
                     sprintf('  %s has been migrated %s', $file->getFilename(), $stageString)
                 );
                 foreach ($results['Operations'] as $origin => $destination) {
-                    $this->logger->debug(sprintf(' related thumbnail %s moved to %s', $origin, $destination));
+                    $this->logger->debug(sprintf(' related file %s moved to %s', $origin, $destination));
                 }
                 $count++;
             }


### PR DESCRIPTION
When moving e.g. a pdf or zip archive, the related file is not always a thumbnail.