### PR TITLE
Use short array syntax across the module's codebase

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,6 +19,9 @@
 		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
 	</rule>
 
+	<!-- use short array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+
 	<!-- PHP-PEG generated file not intended for human consumption -->
 	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
     <exclude-pattern>*/_fakewebroot/*</exclude-pattern>

--- a/src/AssetControlExtension.php
+++ b/src/AssetControlExtension.php
@@ -164,9 +164,9 @@ class AssetControlExtension extends DataExtension
         // Unauthenticated member to use for checking visibility
         $baseClass = $this->owner->baseClass();
         $baseTable = $this->owner->baseTable();
-        $filter = array(
+        $filter = [
             Convert::symbol2sql("{$baseTable}.ID") => $this->owner->ID,
-        );
+        ];
         $stages = $this->owner->getVersionedStages(); // {@see Versioned::getVersionedStages}
         foreach ($stages as $stage) {
             // Skip current stage; These should be handled explicitly
@@ -219,7 +219,7 @@ class AssetControlExtension extends DataExtension
     protected function findAssets(DataObject $record)
     {
         // Search for dbfile instances
-        $files = array();
+        $files = [];
         $fields = DataObject::getSchema()->fieldSpecs($record);
         foreach ($fields as $field => $db) {
             $fieldObj = $record->$field;

--- a/src/AssetManipulationList.php
+++ b/src/AssetManipulationList.php
@@ -29,21 +29,21 @@ class AssetManipulationList
      *
      * @var array
      */
-    protected $public = array();
+    protected $public = [];
 
     /**
      * List of protected assets
      *
      * @var array
      */
-    protected $protected = array();
+    protected $protected = [];
 
     /**
      * List of deleted assets
      *
      * @var array
      */
-    protected $deleted = array();
+    protected $deleted = [];
 
     /**
      * Get an identifying key for a given filename and hash

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -514,7 +514,7 @@ class FileMigrationHelper
         /** @skipUpgrade */
         return File::get()
             ->exclude('ClassName', [Folder::class, 'Folder'])
-            ->filter('FileFilename', array('', null))
+            ->filter('FileFilename', ['', null])
             ->where(sprintf(
                 '"%s"."Filename" IS NOT NULL AND "%s"."Filename" != \'\'',
                 $table,

--- a/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
+++ b/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
@@ -222,7 +222,7 @@ class LegacyThumbnailMigrationHelper
         /** @skipUpgrade */
         return File::get()
             ->filter('ClassName', [Folder::class, 'Folder'])
-            ->filter('FileFilename', array('', null))
+            ->filter('FileFilename', ['', null])
             ->alterDataQuery(function (DataQuery $query) use ($table) {
                 return $query->addSelectFromTable($table, ['Filename']);
             });

--- a/src/File.php
+++ b/src/File.php
@@ -126,18 +126,18 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      */
     private static $non_live_permissions = ['CMS_ACCESS', 'VIEW_DRAFT_CONTENT'];
 
-    private static $db = array(
+    private static $db = [
         "Name" => "Varchar(255)",
         "Title" => "Varchar(255)",
         "File" => "DBFile",
         // Only applies to files, doesn't inherit for folder
         'ShowInSearch' => 'Boolean(1)',
-    );
+    ];
 
-    private static $has_one = array(
+    private static $has_one = [
         "Parent" => File::class,
         "Owner" => Member::class,
-    );
+    ];
 
     private static $has_many = [
         'BackLinks' => FileLink::class . '.Linked',
@@ -147,25 +147,25 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         'BackLinks',
     ];
 
-    private static $indexes = array(
+    private static $indexes = [
         'FileHash' => true
-    );
+    ];
 
-    private static $defaults = array(
+    private static $defaults = [
         "ShowInSearch" => 1,
-    );
+    ];
 
-    private static $extensions = array(
+    private static $extensions = [
         Hierarchy::class,
         InheritedPermissionsExtension::class,
-    );
+    ];
 
-    private static $casting = array (
+    private static $casting = [
         'TreeTitle' => 'HTMLFragment',
         'getTreeTitle' => 'HTMLFragment',
         'Tag' => 'HTMLFragment',
         'getTag' => 'HTMLFragment',
-    );
+    ];
 
     private static $table_name = 'File';
 
@@ -190,46 +190,46 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      *
      * Instructions for the change you need to make are included in a comment in the config file.
      */
-    private static $allowed_extensions = array(
+    private static $allowed_extensions = [
         '', 'ace', 'arc', 'arj', 'asf', 'au', 'avi', 'bmp', 'bz2', 'cab', 'cda', 'csv', 'dmg', 'doc',
         'docx', 'dotx', 'flv', 'gif', 'gpx', 'gz', 'hqx', 'ico', 'jpeg', 'jpg', 'kml',
         'm4a', 'm4v', 'mid', 'midi', 'mkv', 'mov', 'mp3', 'mp4', 'mpa', 'mpeg', 'mpg', 'ogg', 'ogv', 'pages',
         'pcx', 'pdf', 'png', 'pps', 'ppt', 'pptx', 'potx', 'ra', 'ram', 'rm', 'rtf', 'sit', 'sitx',
         'tar', 'tgz', 'tif', 'tiff', 'txt', 'wav', 'webm', 'wma', 'wmv', 'xls', 'xlsx', 'xltx', 'zip',
         'zipx',
-    );
+    ];
 
     /**
      * @config
      * @var array Category identifiers mapped to commonly used extensions.
      */
-    private static $app_categories = array(
-        'archive' => array(
+    private static $app_categories = [
+        'archive' => [
             'ace', 'arc', 'arj', 'bz', 'bz2', 'cab', 'dmg', 'gz', 'hqx', 'jar', 'rar', 'sit', 'sitx', 'tar', 'tgz',
             'zip', 'zipx',
-        ),
-        'audio' => array(
+        ],
+        'audio' => [
             'aif', 'aifc', 'aiff', 'apl', 'au', 'avr', 'cda', 'm4a', 'mid', 'midi', 'mp3', 'ogg', 'ra',
             'ram', 'rm', 'snd', 'wav', 'wma',
-        ),
-        'document' => array(
+        ],
+        'document' => [
             'css', 'csv', 'doc', 'docx', 'dotm', 'dotx', 'htm', 'html', 'gpx', 'js', 'kml', 'pages', 'pdf',
             'potm', 'potx', 'pps', 'ppt', 'pptx', 'rtf', 'txt', 'xhtml', 'xls', 'xlsx', 'xltm', 'xltx', 'xml',
-        ),
-        'image' => array(
+        ],
+        'image' => [
             'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff',
-        ),
-        'image/supported' => array(
+        ],
+        'image/supported' => [
             'gif', 'jpeg', 'jpg', 'png', 'bmp', 'ico',
-        ),
-        'flash' => array(
+        ],
+        'flash' => [
             'fla', 'swf'
-        ),
-        'video' => array(
+        ],
+        'video' => [
             'asf', 'avi', 'flv', 'ifo', 'm1v', 'm2v', 'm4v', 'mkv', 'mov', 'mp2', 'mp4', 'mpa', 'mpe', 'mpeg',
             'mpg', 'ogv', 'qt', 'vob', 'webm', 'wmv',
-        ),
-    );
+        ],
+    ];
 
     /**
      * Map of file extensions to class type
@@ -237,7 +237,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      * @config
      * @var
      */
-    private static $class_for_file_extension = array(
+    private static $class_for_file_extension = [
         '*' => File::class,
         'jpg' => Image::class,
         'jpeg' => Image::class,
@@ -245,7 +245,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         'gif' => Image::class,
         'bmp' => Image::class,
         'ico' => Image::class,
-    );
+    ];
 
     /**
      * @config
@@ -301,10 +301,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         /** @var File $item */
         $item = null;
         foreach ($parts as $part) {
-            $item = File::get()->filter(array(
+            $item = File::get()->filter([
                 'Name' => $part,
                 'ParentID' => $parentID
-            ))->first();
+            ])->first();
             if (!$item) {
                 break;
             }
@@ -429,7 +429,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      * @param array $context
      * @return boolean
      */
-    public function canCreate($member = null, $context = array())
+    public function canCreate($member = null, $context = [])
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -558,12 +558,12 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     public static function get_category_extensions($categories)
     {
         if (empty($categories)) {
-            return array();
+            return [];
         }
 
         // Fix arguments into a single array
         if (!is_array($categories)) {
-            $categories = array($categories);
+            $categories = [$categories];
         } elseif (count($categories) === 1 && is_array(reset($categories))) {
             $categories = reset($categories);
         }
@@ -572,7 +572,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         $appCategories = static::config()->get('app_categories');
 
         // Merge all categories into list of extensions
-        $extensions = array();
+        $extensions = [];
         foreach (array_filter($categories) as $category) {
             if (isset($appCategories[$category])) {
                 $extensions = array_merge($extensions, $appCategories[$category]);
@@ -637,12 +637,12 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
 
                 // TODO Add read lock to avoid other processes creating files with the same name
                 // before this process has a chance to persist in the database.
-                $existingFile = File::get()->filter(array(
+                $existingFile = File::get()->filter([
                     'Name' => $newName,
                     'ParentID' => (int) $this->ParentID
-                ))->exclude(array(
+                ])->exclude([
                     'ID' => $this->ID
-                ))->first();
+                ])->first();
                 if (!$existingFile) {
                     $name = $newName;
                     break;
@@ -659,7 +659,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             // and any file extensions removed.
             $this->setField(
                 'Title',
-                str_replace(array('-','_'), ' ', preg_replace('/\.[^.]+$/', '', $name))
+                str_replace(['-','_'], ' ', preg_replace('/\.[^.]+$/', '', $name))
             );
         }
 
@@ -1102,7 +1102,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     public static function set_class_for_file_extension($exts, $class)
     {
         if (!is_array($exts)) {
-            $exts = array($exts);
+            $exts = [$exts];
         }
         foreach ($exts as $ext) {
             if (!is_subclass_of($class, File::class)) {
@@ -1146,7 +1146,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         return $this->File->getString();
     }
 
-    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = array())
+    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = [])
     {
         $result = $this->File->setFromLocalFile($path, $filename, $hash, $variant, $config);
 
@@ -1157,7 +1157,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         return $result;
     }
 
-    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = [])
     {
         $result = $this->File->setFromStream($stream, $filename, $hash, $variant, $config);
 
@@ -1168,7 +1168,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         return $result;
     }
 
-    public function setFromString($data, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromString($data, $filename, $hash = null, $variant = null, $config = [])
     {
         $result = $this->File->setFromString($data, $filename, $hash, $variant, $config);
 
@@ -1269,7 +1269,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             $args = $args[0];
         }
 
-        $parts = array();
+        $parts = [];
         foreach ($args as $arg) {
             $part = trim($arg, ' \\/');
             if ($part) {

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -36,9 +36,9 @@ class FileFinder
     /**
      * @var array
      */
-    protected static $vcs_dirs = array(
+    protected static $vcs_dirs = [
         '.git', '.svn', '.hg', '.bzr', 'node_modules',
-    );
+    ];
 
     /**
      * The default options that are set on a new finder instance. Options not
@@ -49,7 +49,7 @@ class FileFinder
      *
      * @var array
      */
-    protected static $default_options = array(
+    protected static $default_options = [
         'name_regex'           => null,
         'dir_regex'            => null,
         'accept_callback'      => null,
@@ -62,7 +62,7 @@ class FileFinder
         'ignore_vcs'           => true,
         'min_depth'            => null,
         'max_depth'            => null
-    );
+    ];
 
     /**
      * @var array
@@ -140,8 +140,8 @@ class FileFinder
             $base = '/';
         }
 
-        $paths = array(array($base, 0));
-        $found = array();
+        $paths = [[$base, 0]];
+        $found = [];
 
         $fileCallback = $this->getOption('file_callback');
         $dirCallback  = $this->getOption('dir_callback');
@@ -168,7 +168,7 @@ class FileFinder
                         );
                     }
 
-                    $paths[] = array("$path/$basename", $depth + 1);
+                    $paths[] = ["$path/$basename", $depth + 1];
                 } else {
                     if (!$this->acceptFile($basename, "$path/$basename", $depth)) {
                         continue;

--- a/src/FileNameFilter.php
+++ b/src/FileNameFilter.php
@@ -57,7 +57,7 @@ class FileNameFilter
     /**
      * @var array See {@link setReplacements()}
      */
-    public $replacements = array();
+    public $replacements = [];
 
     /**
      * Depending on the applied replacement rules, this method

--- a/src/Flysystem/AssetAdapter.php
+++ b/src/Flysystem/AssetAdapter.php
@@ -26,7 +26,7 @@ class AssetAdapter extends Local
      * @config
      * @var array Mapping of server configurations to configuration files necessary
      */
-    private static $server_configuration = array();
+    private static $server_configuration = [];
 
     /**
      * Default server configuration to use if the server type defined by the environment is not found
@@ -42,7 +42,7 @@ class AssetAdapter extends Local
      * @config
      * @var array
      */
-    private static $file_permissions = array(
+    private static $file_permissions = [
         'file' => [
             'public' => 0664,
             'private' => 0600,
@@ -51,7 +51,7 @@ class AssetAdapter extends Local
             'public' => 0775,
             'private' => 0700,
         ]
-    );
+    ];
 
     public function __construct($root = null, $writeFlags = LOCK_EX, $linkHandling = self::DISALLOW_LINKS)
     {

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -134,9 +134,9 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @config
      * @var array
      */
-    private static $file_response_headers = array(
+    private static $file_response_headers = [
         'Cache-Control' => 'private'
-    );
+    ];
 
     /**
      * Assign new flysystem backend
@@ -429,18 +429,18 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     public function getCapabilities()
     {
-        return array(
-            'visibility' => array(
+        return [
+            'visibility' => [
                 self::VISIBILITY_PUBLIC,
                 self::VISIBILITY_PROTECTED
-            ),
-            'conflict' => array(
+            ],
+            'conflict' => [
                 self::CONFLICT_EXCEPTION,
                 self::CONFLICT_OVERWRITE,
                 self::CONFLICT_RENAME,
                 self::CONFLICT_USE_EXISTING
-            )
-        );
+            ]
+        ];
     }
 
     public function getVisibility($filename, $hash)
@@ -502,7 +502,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         return $publicAdapter->getPublicUrl($fileID);
     }
 
-    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = array())
+    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = [])
     {
         // Validate this file exists
         if (!file_exists($path)) {
@@ -528,7 +528,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         }
     }
 
-    public function setFromString($data, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromString($data, $filename, $hash = null, $variant = null, $config = [])
     {
         $stream = fopen('php://temp', 'r+');
         fwrite($stream, $data);
@@ -542,7 +542,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         }
     }
 
-    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = [])
     {
         if (empty($filename)) {
             throw new InvalidArgumentException('$filename can not be empty');
@@ -971,7 +971,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         $fileID = $this->getFileID($filename, $hash);
 
         $session = Controller::curr()->getRequest()->getSession();
-        $granted = $session->get(self::GRANTS_SESSION) ?: array();
+        $granted = $session->get(self::GRANTS_SESSION) ?: [];
         $granted[$fileID] = true;
         $session->set(self::GRANTS_SESSION, $granted);
     }
@@ -984,7 +984,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         }
 
         $session = Controller::curr()->getRequest()->getSession();
-        $granted = $session->get(self::GRANTS_SESSION) ?: array();
+        $granted = $session->get(self::GRANTS_SESSION) ?: [];
         unset($granted[$fileID]);
         if ($granted) {
             $session->set(self::GRANTS_SESSION, $granted);
@@ -1023,7 +1023,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         // Make sure our File ID got understood
         if ($parsedFileID && $originalID = $parsedFileID->getFileID()) {
             $session = Controller::curr()->getRequest()->getSession();
-            $granted = $session->get(self::GRANTS_SESSION) ?: array();
+            $granted = $session->get(self::GRANTS_SESSION) ?: [];
             if (!empty($granted[$originalID])) {
                 return true;
             }
@@ -1104,7 +1104,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @return array Tuple associative array (Filename, Hash, Variant)
      * @throws FlysystemException
      */
-    protected function writeWithCallback($callback, $filename, $hash, $variant = null, $config = array())
+    protected function writeWithCallback($callback, $filename, $hash, $variant = null, $config = [])
     {
         // Set default conflict resolution
         $conflictResolution = empty($config['conflict'])
@@ -1327,7 +1327,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      */
     protected function fileGeneratorFor($fileID)
     {
-        return Injector::inst()->createWithArgs(AssetNameGenerator::class, array($fileID));
+        return Injector::inst()->createWithArgs(AssetNameGenerator::class, [$fileID]);
     }
 
     /**

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -63,10 +63,10 @@ class Folder extends File
             // err in favour of matching existing folders if $folderPath
             // includes illegal characters itself.
             $partSafe = $filter->filter($part);
-            $item = Folder::get()->filter(array(
+            $item = Folder::get()->filter([
                 'ParentID' => $parentID,
-                'Name' => array($partSafe, $part)
-            ))->first();
+                'Name' => [$partSafe, $part]
+            ])->first();
 
             if (!$item) {
                 $item = new Folder();

--- a/src/Image.php
+++ b/src/Image.php
@@ -25,7 +25,7 @@ class Image extends File
      */
     private static $plural_name = "Images";
 
-    public function __construct($record = null, $isSingleton = false, $queryParams = array())
+    public function __construct($record = null, $isSingleton = false, $queryParams = [])
     {
         parent::__construct($record, $isSingleton, $queryParams);
         $this->File->setAllowedCategories('image/supported');

--- a/src/ImageBackendFactory.php
+++ b/src/ImageBackendFactory.php
@@ -35,7 +35,7 @@ class ImageBackendFactory implements Factory
      * @param array $params The constructor parameters.
      * @return object The created service instances.
      */
-    public function create($service, array $params = array())
+    public function create($service, array $params = [])
     {
         /** @var AssetContainer */
         $store = reset($params);

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -737,7 +737,7 @@ trait ImageManipulation
 
         // Pass to backend service factory
         try {
-            return $this->imageBackend = Injector::inst()->createWithArgs(Image_Backend::class, array($this));
+            return $this->imageBackend = Injector::inst()->createWithArgs(Image_Backend::class, [$this]);
         } catch (InjectorNotFoundException $ex) {
             // Handle file-not-found errors
             return null;
@@ -886,7 +886,7 @@ trait ImageManipulation
                             $filename,
                             $hash,
                             $variant,
-                            array('conflict' => AssetStore::CONFLICT_USE_EXISTING)
+                            ['conflict' => AssetStore::CONFLICT_USE_EXISTING]
                         );
 
                         return [$tuple, $result];
@@ -959,11 +959,11 @@ trait ImageManipulation
                 list($tuple, $manipulationResult) = $result;
             }
         } else {
-            $tuple = array(
+            $tuple = [
                 'Filename' => $filename,
                 'Hash' => $hash,
                 'Variant' => $variant
-            );
+            ];
         }
 
         // Callback may fail to perform this manipulation (e.g. resize on text file)

--- a/src/Image_Backend.php
+++ b/src/Image_Backend.php
@@ -84,7 +84,7 @@ interface Image_Backend
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the given data.
      */
-    public function writeToStore(AssetStore $assetStore, $filename, $hash = null, $variant = null, $config = array());
+    public function writeToStore(AssetStore $assetStore, $filename, $hash = null, $variant = null, $config = []);
 
     /**
      * Write the backend to a local path

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -355,7 +355,7 @@ class InterventionBackend implements Image_Backend, Flushable
      * will be calculated from the given data.
      * @throws BadMethodCallException If image isn't valid
      */
-    public function writeToStore(AssetStore $assetStore, $filename, $hash = null, $variant = null, $config = array())
+    public function writeToStore(AssetStore $assetStore, $filename, $hash = null, $variant = null, $config = [])
     {
         try {
             $resource = $this->getImageResource();

--- a/src/Shortcodes/FileLinkTrackingParser.php
+++ b/src/Shortcodes/FileLinkTrackingParser.php
@@ -26,7 +26,7 @@ class FileLinkTrackingParser
      */
     public function process(HTMLValue $htmlValue)
     {
-        $results = array();
+        $results = [];
         $links = $htmlValue->getElementsByTagName('a');
         if (!$links) {
             return $results;
@@ -46,24 +46,24 @@ class FileLinkTrackingParser
             // Link to a file on this site.
             if (preg_match('/\[file_link([^\]]+)\bid=(["])?(?<id>\d+)\D/i', $href, $matches)) {
                 $id = (int)$matches['id'];
-                $results[] = array(
+                $results[] = [
                     'Type' => 'file',
                     'Target' => $id,
                     'DOMReference' => $link,
                     'Broken' => (int)File::get()->filter('ID', $id)->count() === 0
-                );
+                ];
             }
         }
 
         // Find all [image ] shortcodes (will be inline, not inside attributes)
         if (preg_match_all('/\[image([^\]]+)\bid=(["])?(?<id>\d+)\D/i', $htmlValue->getContent(), $matches)) {
             foreach ($matches['id'] as $id) {
-                $results[] = array(
+                $results[] = [
                     'Type' => 'image',
                     'Target' => (int)$id,
                     'DOMReference' => null,
                     'Broken' => (int)Image::get()->filter('ID', (int)$id)->count() === 0
-                );
+                ];
             }
         }
 

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -71,7 +71,7 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
      *
      * @return string Result of the handled shortcode
      */
-    public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = array())
+    public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = [])
     {
         /** @var CacheInterface $cache */
         $cache = static::getCache();

--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -28,7 +28,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
      */
     public static function get_shortcodes()
     {
-        return array('image');
+        return ['image'];
     }
 
     /**
@@ -42,7 +42,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
      * @param array $extra Extra arguments
      * @return string Result of the handled shortcode
      */
-    public static function handle_shortcode($args, $content, $parser, $shortcode, $extra = array())
+    public static function handle_shortcode($args, $content, $parser, $shortcode, $extra = [])
     {
         $cache = static::getCache();
         $cacheKey = static::getCacheKey($args);
@@ -128,7 +128,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
      * @param array $extra Extra arguments
      * @return string Result of the handled shortcode
      */
-    public static function regenerate_shortcode($args, $content, $parser, $shortcode, $extra = array())
+    public static function regenerate_shortcode($args, $content, $parser, $shortcode, $extra = [])
     {
         // Check if there is a suitable record
         $record = static::find_shortcode_record($args);
@@ -137,7 +137,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
         }
 
         // Rebuild shortcode
-        $parts = array();
+        $parts = [];
         foreach ($args as $name => $value) {
             $htmlValue = Convert::raw2att($value ?: $name);
             $parts[] = sprintf('%s="%s"', $name, $htmlValue);

--- a/src/Storage/AssetContainer.php
+++ b/src/Storage/AssetContainer.php
@@ -24,7 +24,7 @@ interface AssetContainer
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the given data.
      */
-    public function setFromString($data, $filename, $hash = null, $variant = null, $config = array());
+    public function setFromString($data, $filename, $hash = null, $variant = null, $config = []);
 
     /**
      * Assign a local file to the backend.
@@ -38,7 +38,7 @@ interface AssetContainer
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the local file content.
      */
-    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = array());
+    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = []);
 
     /**
      * Assign a stream to the backend
@@ -51,7 +51,7 @@ interface AssetContainer
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the raw stream.
      */
-    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = array());
+    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = []);
 
     /**
      * @return string Data from the file in this container

--- a/src/Storage/AssetStore.php
+++ b/src/Storage/AssetStore.php
@@ -96,7 +96,7 @@ interface AssetStore
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the given data.
      */
-    public function setFromString($data, $filename, $hash = null, $variant = null, $config = array());
+    public function setFromString($data, $filename, $hash = null, $variant = null, $config = []);
 
     /**
      * Assign a local file to the backend.
@@ -110,7 +110,7 @@ interface AssetStore
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the local file content.
      */
-    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = array());
+    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = []);
 
     /**
      * Assign a stream to the backend
@@ -123,7 +123,7 @@ interface AssetStore
      * @return array Tuple associative array (Filename, Hash, Variant) Unless storing a variant, the hash
      * will be calculated from the raw stream.
      */
-    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = array());
+    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = []);
 
     /**
      * Get contents of a given file

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -31,7 +31,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      *
      * @var array
      */
-    protected $allowedCategories = array();
+    protected $allowedCategories = [];
 
     /**
      * List of image mime types supported by the image manipulations API
@@ -41,7 +41,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      * @config
      * @var array
      */
-    private static $supported_images = array(
+    private static $supported_images = [
         'image/jpg',
         'image/jpeg',
         'image/pjpeg',
@@ -64,7 +64,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         'image/x-icon',
         'image/vnd.microsoft.icon',
         'image/vnd.adobe.photoshop',
-    );
+    ];
 
     /**
      * Create a new image manipulation
@@ -72,7 +72,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      * @param string $name
      * @param array|string $allowed List of allowed file categories (not extensions), as per File::$app_categories
      */
-    public function __construct($name = null, $allowed = array())
+    public function __construct($name = null, $allowed = [])
     {
         parent::__construct($name);
         $this->setAllowedCategories($allowed);
@@ -99,13 +99,13 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         return Injector::inst()->get(AssetStore::class);
     }
 
-    private static $composite_db = array(
+    private static $composite_db = [
         "Hash" => "Varchar(255)", // SHA of the base content
         "Filename" => "Varchar(255)", // Path identifier of the base content
         "Variant" => "Varchar(255)", // Identifier of the variant to the base, if given
-    );
+    ];
 
-    private static $casting = array(
+    private static $casting = [
         'URL' => 'Varchar',
         'AbsoluteURL' => 'Varchar',
         'Basename' => 'Varchar',
@@ -114,7 +114,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         'String' => 'Text',
         'Tag' => 'HTMLFragment',
         'Size' => 'Varchar'
-    );
+    ];
 
     public function scaffoldFormField($title = null, $params = null)
     {
@@ -208,7 +208,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         return $this->getBasename();
     }
 
-    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = array())
+    public function setFromLocalFile($path, $filename = null, $hash = null, $variant = null, $config = [])
     {
         $this->assertFilenameValid($filename ?: $path);
         $result = $this
@@ -221,7 +221,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         return $result;
     }
 
-    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromStream($stream, $filename, $hash = null, $variant = null, $config = [])
     {
         $this->assertFilenameValid($filename);
         $result = $this
@@ -234,7 +234,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         return $result;
     }
 
-    public function setFromString($data, $filename, $hash = null, $variant = null, $config = array())
+    public function setFromString($data, $filename, $hash = null, $variant = null, $config = [])
     {
         $this->assertFilenameValid($filename);
         $result = $this
@@ -340,11 +340,11 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         if (!$this->exists()) {
             return null;
         }
-        return array(
+        return [
             'Filename' => $this->Filename,
             'Hash' => $this->Hash,
             'Variant' => $this->Variant
-        );
+        ];
     }
 
     public function getVisibility()

--- a/src/Storage/ProtectedFileController.php
+++ b/src/Storage/ProtectedFileController.php
@@ -38,13 +38,13 @@ class ProtectedFileController extends Controller
         return $this;
     }
 
-    private static $url_handlers = array(
+    private static $url_handlers = [
         '$Filename' => "handleFile"
-    );
+    ];
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'handleFile'
-    );
+    ];
 
     /**
      * Provide a response for the given file request

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -32,10 +32,10 @@ use SilverStripe\Security\Security;
 class Upload extends Controller
 {
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'index',
         'load'
-    );
+    ];
 
     /**
      * A dataobject (typically {@see File}) which implements {@see AssetContainer}
@@ -72,7 +72,7 @@ class Upload extends Controller
      *
      * @var array
      */
-    protected $errors = array();
+    protected $errors = [];
 
     /**
      * Default visibility to assign uploaded files
@@ -143,7 +143,7 @@ class Upload extends Controller
      */
     protected function getNameGenerator($filename)
     {
-        return Injector::inst()->createWithArgs(AssetNameGenerator::class, array($filename));
+        return Injector::inst()->createWithArgs(AssetNameGenerator::class, [$filename]);
     }
 
     /**
@@ -226,10 +226,10 @@ class Upload extends Controller
         $conflictResolution = $this->replaceFile
             ? AssetStore::CONFLICT_OVERWRITE
             : AssetStore::CONFLICT_RENAME;
-        $config = array(
+        $config = [
             'conflict' => $conflictResolution,
             'visibility' => $this->getDefaultVisibility()
-        );
+        ];
         return $container->setFromLocalFile($tmpFile['tmp_name'], $filename, null, null, $config);
     }
 
@@ -388,7 +388,7 @@ class Upload extends Controller
      */
     public function clearErrors()
     {
-        $this->errors = array();
+        $this->errors = [];
         $this->validator->clearErrors();
     }
 

--- a/src/Upload_Validator.php
+++ b/src/Upload_Validator.php
@@ -19,7 +19,7 @@ class Upload_Validator
      * @config
      * @var array
      */
-    private static $default_max_file_size = array();
+    private static $default_max_file_size = [];
 
     /**
      * Set to false to assume is_uploaded_file() is true,
@@ -39,7 +39,7 @@ class Upload_Validator
      */
     protected $tmpFile;
 
-    protected $errors = array();
+    protected $errors = [];
 
     /**
      * Restrict filesize for either all filetypes
@@ -48,7 +48,7 @@ class Upload_Validator
      *
      * @var array
      */
-    public $allowedMaxFileSize = array();
+    public $allowedMaxFileSize = [];
 
     /**
      * @var array Collection of extensions.
@@ -59,7 +59,7 @@ class Upload_Validator
      *    array("jpg","GIF")
      * </code>
      */
-    public $allowedExtensions = array();
+    public $allowedExtensions = [];
 
     /**
      * Return all errors that occurred while validating
@@ -77,7 +77,7 @@ class Upload_Validator
      */
     public function clearErrors()
     {
-        $this->errors = array();
+        $this->errors = [];
     }
 
     /**
@@ -159,7 +159,7 @@ class Upload_Validator
         if (is_array($rules) && count($rules)) {
             // make sure all extensions are lowercase
             $rules = array_change_key_case($rules, CASE_LOWER);
-            $finalRules = array();
+            $finalRules = [];
 
             foreach ($rules as $rule => $value) {
                 if (is_numeric($value)) {
@@ -312,7 +312,7 @@ class Upload_Validator
                 'SilverStripe\\Assets\\File.TOOLARGE',
                 'Filesize is too large, maximum {size} allowed',
                 'Argument 1: Filesize (e.g. 1MB)',
-                array('size' => $arg)
+                ['size' => $arg]
             );
             return false;
         }

--- a/tests/php/AssetControlExtensionTest.php
+++ b/tests/php/AssetControlExtensionTest.php
@@ -20,10 +20,10 @@ use SilverStripe\Versioned\Versioned;
 class AssetControlExtensionTest extends SapphireTest
 {
 
-    protected static $extra_dataobjects = array(
+    protected static $extra_dataobjects = [
         VersionedObject::class,
         TestObject::class
-    );
+    ];
 
     public function setUp()
     {
@@ -98,12 +98,12 @@ class AssetControlExtensionTest extends SapphireTest
         $object1Live = Versioned::get_one_by_stage(
             VersionedObject::class,
             'Live',
-            array('"ID"' => $object1->ID)
+            ['"ID"' => $object1->ID]
         );
         $object3Live = Versioned::get_one_by_stage(
             ArchivedObject::class,
             'Live',
-            array('"ID"' => $object3->ID)
+            ['"ID"' => $object3->ID]
         );
         $this->assertTrue($object1Live->Download->exists());
         $this->assertTrue($object1Live->Header->exists());

--- a/tests/php/AssetControlExtensionTest/TestObject.php
+++ b/tests/php/AssetControlExtensionTest/TestObject.php
@@ -16,10 +16,10 @@ use SilverStripe\Versioned\Versioned;
  */
 class TestObject extends DataObject implements TestOnly
 {
-    private static $db = array(
+    private static $db = [
         'Title' => 'Varchar(255)',
         'Image' => "DBFile('image/supported')"
-    );
+    ];
 
     private static $table_name = 'AssetControlExtensionTest_TestObject';
 

--- a/tests/php/AssetControlExtensionTest/VersionedObject.php
+++ b/tests/php/AssetControlExtensionTest/VersionedObject.php
@@ -19,15 +19,15 @@ use SilverStripe\Security\Member;
  */
 class VersionedObject extends DataObject implements TestOnly
 {
-    private static $extensions = array(
+    private static $extensions = [
         Versioned::class
-    );
+    ];
 
-    private static $db = array(
+    private static $db = [
         'Title' => 'Varchar(255)',
         'Header' => "DBFile('image/supported')",
         'Download' => 'DBFile'
-    );
+    ];
 
     private static $table_name = 'AssetControlExtensionTest_VersionedObject';
 

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -32,11 +32,11 @@ class FileMigrationHelperTest extends SapphireTest
 
     private $expectedContent = [];
 
-    protected static $required_extensions = array(
-        File::class => array(
+    protected static $required_extensions = [
+        File::class => [
             Extension::class,
-        )
-    );
+        ]
+    ];
 
     /**
      * get the BASE_PATH for this test

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest/Extension.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest/Extension.php
@@ -14,9 +14,9 @@ class Extension extends DataExtension implements TestOnly
     /**
      * Ensure that File dataobject has the legacy "Filename" field
      */
-    private static $db = array(
+    private static $db = [
         "Filename" => "Text",
-    );
+    ];
 
     public function onBeforeWrite()
     {

--- a/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/LegacyThumbnailMigrationHelperTest.php
@@ -23,11 +23,11 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
 
     protected static $fixture_file = 'LegacyThumbnailMigrationHelperTest.yml';
 
-    protected static $required_extensions = array(
-        File::class => array(
+    protected static $required_extensions = [
+        File::class => [
             Extension::class,
-        )
-    );
+        ]
+    ];
 
     /**
      * get the BASE_PATH for this test
@@ -381,7 +381,7 @@ class LegacyThumbnailMigrationHelperTest extends SapphireTest
      */
     protected function joinPaths()
     {
-        $paths = array();
+        $paths = [];
 
         foreach (func_get_args() as $arg) {
             if ($arg !== '') {

--- a/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
@@ -39,11 +39,11 @@ class SS4FileMigrationHelperTest extends SapphireTest
 
     protected static $fixture_file = '../../FileTest.yml';
 
-    protected static $required_extensions = array(
-        File::class => array(
+    protected static $required_extensions = [
+        File::class => [
             Extension::class,
-        )
-    );
+        ]
+    ];
 
     public function setUp()
     {

--- a/tests/php/FileFinderTest.php
+++ b/tests/php/FileFinderTest.php
@@ -24,14 +24,14 @@ class FileFinderTest extends SapphireTest
     {
         $this->assertFinderFinds(
             new FileFinder(),
-            array(
+            [
                 'file1.txt',
                 'file2.txt',
                 'dir1/dir1file1.txt',
                 'dir1/dir1file2.txt',
                 'dir1/dir2/dir2file1.txt',
                 'dir1/dir2/dir3/dir3file1.txt'
-            )
+            ]
         );
     }
 
@@ -51,9 +51,9 @@ class FileFinderTest extends SapphireTest
 
         $this->assertFinderFinds(
             $finder,
-            array(
+            [
                 'file2.txt',
-                'dir1/dir1file2.txt'),
+                'dir1/dir1file2.txt'],
             'The finder only returns files matching the name regex.'
         );
     }
@@ -61,14 +61,14 @@ class FileFinderTest extends SapphireTest
     public function testIgnoreFiles()
     {
         $finder = new FileFinder();
-        $finder->setOption('ignore_files', array('file1.txt', 'dir1file1.txt', 'dir2file1.txt'));
+        $finder->setOption('ignore_files', ['file1.txt', 'dir1file1.txt', 'dir2file1.txt']);
 
         $this->assertFinderFinds(
             $finder,
-            array(
+            [
                 'file2.txt',
                 'dir1/dir1file2.txt',
-                'dir1/dir2/dir3/dir3file1.txt'),
+                'dir1/dir2/dir3/dir3file1.txt'],
             'The finder ignores files with the basename in the ignore_files setting.'
         );
     }
@@ -76,15 +76,15 @@ class FileFinderTest extends SapphireTest
     public function testIgnoreDirs()
     {
         $finder = new FileFinder();
-        $finder->setOption('ignore_dirs', array('dir2'));
+        $finder->setOption('ignore_dirs', ['dir2']);
 
         $this->assertFinderFinds(
             $finder,
-            array(
+            [
                 'file1.txt',
                 'file2.txt',
                 'dir1/dir1file1.txt',
-                'dir1/dir1file2.txt'),
+                'dir1/dir1file2.txt'],
             'The finder ignores directories in ignore_dirs.'
         );
     }
@@ -96,10 +96,10 @@ class FileFinderTest extends SapphireTest
 
         $this->assertFinderFinds(
             $finder,
-            array(
+            [
                 'dir1/dir2/dir2file1.txt',
                 'dir1/dir2/dir3/dir3file1.txt'
-            ),
+            ],
             'The finder respects the min depth setting.'
         );
     }
@@ -111,11 +111,11 @@ class FileFinderTest extends SapphireTest
 
         $this->assertFinderFinds(
             $finder,
-            array(
+            [
                 'file1.txt',
                 'file2.txt',
                 'dir1/dir1file1.txt',
-                'dir1/dir1file2.txt'),
+                'dir1/dir1file2.txt'],
             'The finder respects the max depth setting.'
         );
     }

--- a/tests/php/FileNameFilterTest.php
+++ b/tests/php/FileNameFilterTest.php
@@ -52,7 +52,7 @@ class FileNameFilterTest extends SapphireTest
         $name = 'Kuchen ist besser.jpg';
         $filter = new FileNameFilter();
         $filter->setTransliterator(false);
-        $filter->setReplacements(array('/[\s-]/' => '_'));
+        $filter->setReplacements(['/[\s-]/' => '_']);
         $this->assertEquals(
             'Kuchen_ist_besser.jpg',
             $filter->filter($name)

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -29,9 +29,9 @@ class FileTest extends SapphireTest
 
     protected static $fixture_file = 'FileTest.yml';
 
-    protected static $extra_dataobjects = array(
+    protected static $extra_dataobjects = [
         MyCustomFile::class
-    );
+    ];
 
     public function setUp()
     {
@@ -56,10 +56,10 @@ class FileTest extends SapphireTest
         // Conditional fixture creation in case the 'cms' module is installed
         if (class_exists(ErrorPage::class)) {
             $page = new ErrorPage(
-                array(
+                [
                 'Title' => 'Page not Found',
                 'ErrorCode' => 404
-                )
+                ]
             );
             $page->write();
             $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
@@ -134,7 +134,7 @@ class FileTest extends SapphireTest
     {
         $this->logOut();
 
-        Config::modify()->set(File::class, 'allowed_extensions', array('txt'));
+        Config::modify()->set(File::class, 'allowed_extensions', ['txt']);
 
         /** @var File $file */
         $file = $this->objFromFixture(File::class, 'asdf');
@@ -206,18 +206,18 @@ class FileTest extends SapphireTest
     public function testGetCategoryExtensions()
     {
         // Test specific categories
-        $images = array(
+        $images = [
             'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff'
-        );
+        ];
         $this->assertEquals($images, File::get_category_extensions('image'));
         $this->assertEquals(
-            array('bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png'),
+            ['bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png'],
             File::get_category_extensions('image/supported')
         );
-        $this->assertEquals($images, File::get_category_extensions(array('image', 'image/supported')));
+        $this->assertEquals($images, File::get_category_extensions(['image', 'image/supported']));
         $this->assertEquals(
-            array('bmp', 'fla', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'swf'),
-            File::get_category_extensions(array('flash', 'image/supported'))
+            ['bmp', 'fla', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'swf'],
+            File::get_category_extensions(['flash', 'image/supported'])
         );
 
         // Test other categories have at least one item
@@ -338,7 +338,7 @@ class FileTest extends SapphireTest
     public function testSetNameWithInvalidExtensionDoesntChangeFilesystem()
     {
         $this->expectException(ValidationException::class);
-        Config::modify()->set(File::class, 'allowed_extensions', array('txt'));
+        Config::modify()->set(File::class, 'allowed_extensions', ['txt']);
 
         /** @var File $file */
         $file = $this->objFromFixture(File::class, 'asdf');

--- a/tests/php/FolderTest.php
+++ b/tests/php/FolderTest.php
@@ -137,9 +137,9 @@ class FolderTest extends SapphireTest
 
         $parentFolder = DataObject::get_one(
             Folder::class,
-            array(
+            [
             '"File"."Name"' => 'parent'
-            )
+            ]
         );
         $this->assertNotNull($parentFolder);
         $this->assertEquals($parentFolder->ID, $folder->ParentID);
@@ -235,9 +235,9 @@ class FolderTest extends SapphireTest
         // ID is prefixed in case Folder is subclassed by project/other module.
         $folder1 = DataObject::get_one(
             Folder::class,
-            array(
+            [
             '"File"."ID"' => $this->idFromFixture(Folder::class, 'folder1')
-            )
+            ]
         );
 
         $folder1->Name = 'FileTest-folder1-changed';

--- a/tests/php/ImageTest.php
+++ b/tests/php/ImageTest.php
@@ -345,7 +345,7 @@ abstract class ImageTest extends SapphireTest
         $imageFirst = $image->Pad(200, 200, 'CCCCCC', 0);
         $imageFilename = $imageFirst->getURL();
             // Encoding of the arguments is duplicated from cacheFilename
-        $neededPart = 'Pad' . Convert::base64url_encode(array(200,200,'CCCCCC', 0));
+        $neededPart = 'Pad' . Convert::base64url_encode([200,200,'CCCCCC', 0]);
         $this->assertContains($neededPart, $imageFilename, 'Filename for cached image is correctly generated');
     }
 

--- a/tests/php/ProtectedFileControllerTest.php
+++ b/tests/php/ProtectedFileControllerTest.php
@@ -67,24 +67,24 @@ class ProtectedFileControllerTest extends FunctionalTest
 
     public function getFilenames()
     {
-        return array(
+        return [
             // Valid names
-            array('name.jpg', true),
-            array('parent/name.jpg', true),
-            array('parent/name', true),
-            array('parent\name.jpg', true),
-            array('parent\name', true),
-            array('name', true),
+            ['name.jpg', true],
+            ['parent/name.jpg', true],
+            ['parent/name', true],
+            ['parent\name.jpg', true],
+            ['parent\name', true],
+            ['name', true],
 
             // Invalid names
-            array('.invalid/name.jpg', false),
-            array('.invalid\name.jpg', false),
-            array('.htaccess', false),
-            array('test/.htaccess.jpg', false),
-            array('name/.jpg', false),
-            array('test\.htaccess.jpg', false),
-            array('name\.jpg', false)
-        );
+            ['.invalid/name.jpg', false],
+            ['.invalid\name.jpg', false],
+            ['.htaccess', false],
+            ['test/.htaccess.jpg', false],
+            ['name/.jpg', false],
+            ['test\.htaccess.jpg', false],
+            ['name\.jpg', false]
+        ];
     }
 
     /**

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -57,11 +57,11 @@ class AssetStoreTest extends SapphireTest
         $puppies1 = 'puppies';
         $puppies1Tuple = $backend->setFromString($puppies1, 'pets/my-puppy.txt');
         $this->assertEquals(
-            array(
+            [
                 'Hash' => '2a17a9cb4be918774e73ba83bd1c1e7d000fdd53',
                 'Filename' => 'pets/my-puppy.txt',
                 'Variant' => '',
-            ),
+            ],
             $puppies1Tuple
         );
 
@@ -71,11 +71,11 @@ class AssetStoreTest extends SapphireTest
         $fish1Tuple = $backend->setFromStream($fish1Stream, 'parent/awesome-fish.jpg');
         fclose($fish1Stream);
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'parent/awesome-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish1Tuple
         );
 
@@ -87,11 +87,11 @@ class AssetStoreTest extends SapphireTest
         fclose($fish2Stream);
 
         $this->assertEquals(
-            array(
+            [
                 'Hash' => '33be1b95cba0358fe54e8b13532162d52f97421c',
                 'Filename' => 'parent/mediocre-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish2Tuple
         );
         TestAssetStore::$seekable_override = null;
@@ -109,11 +109,11 @@ class AssetStoreTest extends SapphireTest
         $this->assertFileExists($fish1);
         $fish1Tuple = $backend->setFromLocalFile($fish1, 'directory/lovely-fish.jpg');
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish1Tuple
         );
 
@@ -130,15 +130,15 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             '',
             null,
-            array('conflict' => AssetStore::CONFLICT_EXCEPTION)
+            ['conflict' => AssetStore::CONFLICT_EXCEPTION]
         );
 
         $this->assertEquals(
-            array(
+            [
                 'Hash' => '33be1b95cba0358fe54e8b13532162d52f97421c',
                 'Filename' => 'directory/lovely-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish2Tuple
         );
         $this->assertEquals(
@@ -153,14 +153,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_RENAME)
+            ['conflict' => AssetStore::CONFLICT_RENAME]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish-v2.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish3Tuple
         );
         $this->assertEquals(
@@ -174,14 +174,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_RENAME)
+            ['conflict' => AssetStore::CONFLICT_RENAME]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish-v3.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish4Tuple
         );
         $this->assertEquals(
@@ -195,14 +195,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_USE_EXISTING)
+            ['conflict' => AssetStore::CONFLICT_USE_EXISTING]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish5Tuple
         );
         $this->assertEquals(
@@ -216,14 +216,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_OVERWRITE)
+            ['conflict' => AssetStore::CONFLICT_OVERWRITE]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish6Tuple
         );
         $this->assertEquals(
@@ -450,11 +450,11 @@ class AssetStoreTest extends SapphireTest
         $this->assertFileExists($fish1);
         $fish1Tuple = $backend->setFromLocalFile($fish1, 'directory/lovely-fish.jpg');
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish1Tuple
         );
         $this->assertFileExists(ASSETS_PATH . '/AssetStoreTest/.protected/directory/a870de278b/lovely-fish.jpg');
@@ -472,7 +472,7 @@ class AssetStoreTest extends SapphireTest
                 'directory/lovely-fish.jpg',
                 null,
                 null,
-                array('conflict' => AssetStore::CONFLICT_EXCEPTION)
+                ['conflict' => AssetStore::CONFLICT_EXCEPTION]
             );
             $this->fail('Writing file with different sha to same location should throw exception');
             return;
@@ -486,14 +486,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_RENAME)
+            ['conflict' => AssetStore::CONFLICT_RENAME]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => '33be1b95cba0358fe54e8b13532162d52f97421c',
                 'Filename' => 'directory/lovely-fish-v2.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish3Tuple
         );
         $this->assertFileExists(ASSETS_PATH . '/AssetStoreTest/.protected/directory/33be1b95cb/lovely-fish-v2.jpg');
@@ -512,11 +512,11 @@ class AssetStoreTest extends SapphireTest
             ['conflict' => AssetStore::CONFLICT_USE_EXISTING, 'visibility' => AssetStore::VISIBILITY_PUBLIC]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => '33be1b95cba0358fe54e8b13532162d52f97421c',
                 'Filename' => 'directory/lovely-fish-v2.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish4Tuple
         );
         $this->assertFileExists(ASSETS_PATH . '/AssetStoreTest/directory/lovely-fish-v2.jpg');
@@ -531,14 +531,14 @@ class AssetStoreTest extends SapphireTest
             'directory/lovely-fish-v2.jpg',
             null,
             null,
-            array('conflict' => AssetStore::CONFLICT_OVERWRITE, 'visibility' => AssetStore::VISIBILITY_PUBLIC)
+            ['conflict' => AssetStore::CONFLICT_OVERWRITE, 'visibility' => AssetStore::VISIBILITY_PUBLIC]
         );
         $this->assertEquals(
-            array(
+            [
                 'Hash' => 'a870de278b475cb75f5d9f451439b2d378e13af1',
                 'Filename' => 'directory/lovely-fish-v2.jpg',
                 'Variant' => '',
-            ),
+            ],
             $fish5Tuple
         );
         $this->assertFileExists(ASSETS_PATH . '/AssetStoreTest/directory/lovely-fish-v2.jpg');

--- a/tests/php/Storage/DBFileTest.php
+++ b/tests/php/Storage/DBFileTest.php
@@ -14,10 +14,10 @@ use SilverStripe\ORM\ValidationException;
 class DBFileTest extends SapphireTest
 {
 
-    protected static $extra_dataobjects = array(
+    protected static $extra_dataobjects = [
         DBFileTest\TestObject::class,
         DBFileTest\Subclass::class,
-    );
+    ];
 
     protected $usesDatabase = true;
 
@@ -86,9 +86,9 @@ class DBFileTest extends SapphireTest
             'private/awesome-fish.jpg',
             null,
             null,
-            array(
+            [
             'visibility' => AssetStore::VISIBILITY_PROTECTED
-            )
+            ]
         );
 
         // Test various file permissions work on DBFile

--- a/tests/php/Storage/DBFileTest/ImageOnly.php
+++ b/tests/php/Storage/DBFileTest/ImageOnly.php
@@ -13,7 +13,7 @@ class ImageOnly extends DataObject implements TestOnly
 {
     private static $table_name = 'DBFileTest_ImageOnly';
 
-    private static $db = array(
+    private static $db = [
         "MyFile" => "DBFile('image/supported')"
-    );
+    ];
 }

--- a/tests/php/Storage/DBFileTest/Subclass.php
+++ b/tests/php/Storage/DBFileTest/Subclass.php
@@ -13,7 +13,7 @@ class Subclass extends TestObject implements TestOnly
 {
     private static $table_name = 'DBFileTest_Subclass';
 
-    private static $db = array(
+    private static $db = [
         "AnotherFile" => "DBFile"
-    );
+    ];
 }

--- a/tests/php/Storage/DBFileTest/TestObject.php
+++ b/tests/php/Storage/DBFileTest/TestObject.php
@@ -13,7 +13,7 @@ class TestObject extends DataObject implements TestOnly
 {
     private static $table_name = 'DBFileTest_TestObject';
 
-    private static $db = array(
+    private static $db = [
         "MyFile" => "DBFile"
-    );
+    ];
 }

--- a/tests/php/UploadTest.php
+++ b/tests/php/UploadTest.php
@@ -68,14 +68,14 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'txt',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
 
@@ -126,30 +126,30 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'txt',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         // test upload into default folder
         $u1 = new Upload();
         $v = new Upload_Validator();
 
-        $v->setAllowedMaxFileSize(array('txt' => 10));
+        $v->setAllowedMaxFileSize(['txt' => 10]);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertFalse($result, 'Load failed because size was too big');
 
-        $v->setAllowedMaxFileSize(array('[document]' => 10));
+        $v->setAllowedMaxFileSize(['[document]' => 10]);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertFalse($result, 'Load failed because size was too big');
 
-        $v->setAllowedMaxFileSize(array('txt' => 200000));
+        $v->setAllowedMaxFileSize(['txt' => 200000]);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertTrue($result, 'Load failed with setting max file size');
@@ -159,26 +159,26 @@ class UploadTest extends SapphireTest
         $this->tmpFilePath = TEMP_PATH . DIRECTORY_SEPARATOR . $tmpFileName;
         file_put_contents($this->tmpFilePath, $tmpFileContent . $tmpFileContent);
 
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'image/jpeg',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'jpg',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
-        $v->setAllowedMaxFileSize(array('[image]' => '40k'));
+        $v->setAllowedMaxFileSize(['[image]' => '40k']);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertTrue($result, 'Load failed with setting max file size');
 
-        $v->setAllowedMaxFileSize(array('[image]' => '1k'));
+        $v->setAllowedMaxFileSize(['[image]' => '1k']);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertFalse($result, 'Load failed because size was too big');
 
-        $v->setAllowedMaxFileSize(array('[image]' => 1000));
+        $v->setAllowedMaxFileSize(['[image]' => 1000]);
         $u1->setValidator($v);
         $result = $u1->loadIntoFile($tmpFile);
         $this->assertFalse($result, 'Load failed because size was too big');
@@ -196,13 +196,13 @@ class UploadTest extends SapphireTest
 
         // Build file
         $upload = new Upload();
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'tmp_name' => $this->tmpFilePath,
             'size' => filesize($this->tmpFilePath),
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         // Test ok
         $this->assertTrue($upload->validate($tmpFile));
@@ -225,7 +225,7 @@ class UploadTest extends SapphireTest
                 'SilverStripe\\Assets\\File.TOOLARGE',
                 'Filesize is too large, maximum {size} allowed',
                 'Argument 1: Filesize (e.g. 1MB)',
-                array('size' => '1 KB')
+                ['size' => '1 KB']
             ),
             $upload->getErrors()
         );
@@ -239,7 +239,7 @@ class UploadTest extends SapphireTest
                 'SilverStripe\\Assets\\File.TOOLARGE',
                 'Filesize is too large, maximum {size} allowed',
                 'Argument 1: Filesize (e.g. 1MB)',
-                array('size' => '1 KB')
+                ['size' => '1 KB']
             ),
             $upload->getErrors()
         );
@@ -286,10 +286,10 @@ class UploadTest extends SapphireTest
         Config::nest();
 
         // Check the max file size uses the config values
-        $configMaxFileSizes = array(
+        $configMaxFileSizes = [
             '[image]' => '1k',
             'txt' => 1000
-        );
+        ];
         Upload_Validator::config()->set('default_max_file_size', $configMaxFileSizes);
         $v = new Upload_Validator();
 
@@ -314,10 +314,10 @@ class UploadTest extends SapphireTest
         );
 
         // Check instance values for max file size
-        $maxFileSizes = array(
+        $maxFileSizes = [
             '[document]' => 2000,
             'txt' => '4k'
-        );
+        ];
         $v = new Upload_Validator();
         $v->setAllowedMaxFileSize($maxFileSizes);
 
@@ -386,17 +386,17 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => '',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
-        $v->setAllowedMaxFileSize(array('' => 10));
+        $v->setAllowedMaxFileSize(['' => 10]);
 
         // test upload into default folder
         $u1 = new Upload();
@@ -415,17 +415,17 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'php',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
-        $v->setAllowedExtensions(array('txt'));
+        $v->setAllowedExtensions(['txt']);
 
         // test upload into default folder
         $u = new Upload();
@@ -611,14 +611,14 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => '',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         // Upload will work if no special validator is set
         $u1 = new Upload();
@@ -627,7 +627,7 @@ class UploadTest extends SapphireTest
 
         // If a validator limiting extensions is applied, then no-extension files are no longer allowed
         $v = new Upload_Validator();
-        $v->setAllowedExtensions(array('txt'));
+        $v->setAllowedExtensions(['txt']);
 
         // test upload into default folder
         $u2 = new Upload();
@@ -645,14 +645,14 @@ class UploadTest extends SapphireTest
         $this->tmpFilePath = implode(DIRECTORY_SEPARATOR, [__DIR__, 'UploadTest', $tmpFileName]);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'tar.gz',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         // test upload into default folder
         $u = new Upload();
@@ -717,17 +717,17 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'txt',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
-        $v->setAllowedExtensions(array(''));
+        $v->setAllowedExtensions(['']);
 
         // test upload into default folder
         $u = new Upload();
@@ -775,17 +775,17 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'txt',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
-        $v->setAllowedExtensions(array(''));
+        $v->setAllowedExtensions(['']);
 
         // test upload into default folder
         $u = new Upload();
@@ -834,14 +834,14 @@ class UploadTest extends SapphireTest
         file_put_contents($this->tmpFilePath, $tmpFileContent);
 
         // emulates the $_FILES array
-        $tmpFile = array(
+        $tmpFile = [
             'name' => $tmpFileName,
             'type' => 'text/plain',
             'size' => filesize($this->tmpFilePath),
             'tmp_name' => $this->tmpFilePath,
             'extension' => 'txt',
             'error' => UPLOAD_ERR_OK,
-        );
+        ];
 
         $v = new Upload_Validator();
 
@@ -915,14 +915,14 @@ class UploadTest extends SapphireTest
             copy(__DIR__ . '/GDTest/images/test_jpg.jpg', $this->tmpFilePath);
 
             // emulates the $_FILES array
-            $tmpFile = array(
+            $tmpFile = [
                 'name' => $tmpFileName,
                 'type' => 'text/plain',
                 'size' => filesize($this->tmpFilePath),
                 'tmp_name' => $this->tmpFilePath,
                 'extension' => 'jpg',
                 'error' => UPLOAD_ERR_OK,
-            );
+            ];
 
             $v = new Upload_Validator();
 
@@ -956,14 +956,14 @@ class UploadTest extends SapphireTest
             file_put_contents($this->tmpFilePath, $tmpFileContent);
 
             // emulates the $_FILES array
-            $tmpFile = array(
+            $tmpFile = [
                 'name' => $tmpFileName,
                 'type' => 'text/plain',
                 'size' => filesize($this->tmpFilePath),
                 'tmp_name' => $this->tmpFilePath,
                 'extension' => 'jpg',
                 'error' => UPLOAD_ERR_OK,
-            );
+            ];
 
             $v = new Upload_Validator();
 


### PR DESCRIPTION
As per the title — use `[]` instead of `array()`.