### PR TITLE
SilverStripe 3.x to 4.5.x migration toolkit for at least medium sized projects

### DIFF
--- a/src/BatchPublish/Asset/Job.php
+++ b/src/BatchPublish/Asset/Job.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\BatchPublish\Asset;
+
+use App\Queue;
+use SilverStripe\Assets\File;
+use SilverStripe\Versioned\Versioned;
+
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Batch publish asset';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        Versioned::withVersionedMode(function () use ($item): void {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            /** @var File $file */
+            $file = File::get()->byID($item);
+
+            if (!$file || !$file->exists()) {
+                $this->addMessage('File not found ' . $item);
+
+                return;
+            }
+
+            $file->write();
+
+            // force new version to be written
+            $file->copyVersionToStage(Versioned::DRAFT, Versioned::DRAFT);
+
+            $file->publishRecursive();
+        });
+    }
+}

--- a/src/BatchPublish/Asset/Task.php
+++ b/src/BatchPublish/Asset/Task.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\BatchPublish\Asset;
+
+use App\Queue\Factory;
+use SilverStripe\Assets\File;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Versioned\Versioned;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 5;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'batch-publish-asset-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate asset publish jobs';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        Versioned::withVersionedMode(function () use ($request): void {
+            Versioned::set_stage(Versioned::LIVE);
+
+            $list = File::get()->sort('ID', 'ASC');
+            $this->queueJobsFromList($request, $list, Job::class, self::CHUNK_SIZE);
+        });
+    }
+}

--- a/src/BatchPublish/Folder/Job.php
+++ b/src/BatchPublish/Folder/Job.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\BatchPublish\Folder;
+
+use App\Queue;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Versioned\Versioned;
+
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Batch publish folder';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        Versioned::withVersionedMode(function () use ($item): void {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            /** @var Folder $folder */
+            $folder = Folder::get()->byID($item);
+
+            if (!$folder) {
+                $this->addMessage('Folder not found ' . $item);
+
+                return;
+            }
+
+            if ($folder->isPublished()) {
+                return;
+            }
+
+            $folder->write();
+
+            // force new version to be written
+            $folder->copyVersionToStage(Versioned::DRAFT, Versioned::DRAFT);
+
+            $folder->publishRecursive();
+        });
+    }
+}

--- a/src/BatchPublish/Folder/Task.php
+++ b/src/BatchPublish/Folder/Task.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\BatchPublish\Folder;
+
+use App\Queue\Factory;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Versioned\Versioned;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 1;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'batch-publish-folder-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate folder publish jobs';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        Versioned::withVersionedMode(function () use ($request): void {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            $list = Folder::get()
+                ->sort('ID', 'ASC');
+
+            $this->queueJobsFromList($request, $list, Job::class, self::CHUNK_SIZE);
+        });
+    }
+}

--- a/src/BatchPublish/Page/Job.php
+++ b/src/BatchPublish/Page/Job.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\BatchPublish\Page;
+
+use App\Queue;
+use Page;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Versioned\Versioned;
+
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Batch publish page';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        Versioned::withVersionedMode(function () use ($item): void {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            /** @var SiteTree $page */
+            $page = SiteTree::get()->byID($item);
+
+            if ($page === null) {
+                $this->addMessage('Page not found ' . $item);
+
+                return;
+            }
+
+            Page::singleton()->withSkippedSiblingSortPublish(static function () use ($page): void {
+                $page->write();
+
+                // force new version to be written
+                $page->copyVersionToStage(Versioned::DRAFT, Versioned::DRAFT);
+
+                $page->publishRecursive();
+            });
+        });
+    }
+}

--- a/src/BatchPublish/Page/Task.php
+++ b/src/BatchPublish/Page/Task.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\BatchPublish\Page;
+
+use App\Queue\Factory;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Versioned\Versioned;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 1;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'batch-publish-page-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate page publish jobs';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        Versioned::withVersionedMode(function () use ($request): void {
+            Versioned::set_stage(Versioned::LIVE);
+
+            $list = SiteTree::get()->sort('ID', 'ASC');
+            $this->queueJobsFromList($request, $list, Job::class, self::CHUNK_SIZE);
+        });
+    }
+}

--- a/src/FileMigration/FileBinary/Helper.php
+++ b/src/FileMigration/FileBinary/Helper.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\FileMigration\FileBinary;
+
+use Generator;
+use SilverStripe\Assets\Dev\Tasks\FileMigrationHelper;
+use SilverStripe\Assets\File;
+use SilverStripe\ORM\DataList;
+
+class Helper extends FileMigrationHelper
+{
+
+    /**
+     * @var array
+     */
+    private $ids = [];
+
+    public function setIds(array $ids): self
+    {
+        $this->ids = $ids;
+
+        return $this;
+    }
+
+    public function getFileQuery(): DataList
+    {
+        // public scope change
+        return parent::getFileQuery();
+    }
+
+    /**
+     * Code taken from @see FileMigrationHelper::chunk()
+     *
+     * @param DataList $query
+     * @return Generator
+     */
+    protected function chunk(DataList $query): Generator
+    {
+        // only select specified files
+        $query = $query->byIDs($this->ids);
+
+        // the rest of the code is just a copy from base
+        $chunkSize = 100;
+        $greaterThanID = 0;
+        $query = $query->limit($chunkSize)->sort('ID');
+
+        while ($chunk = $query->filter('ID:GreaterThan', $greaterThanID)) {
+            /** @var File $file */
+            foreach ($chunk as $file) {
+                yield $file;
+            }
+
+            if ($chunk->count() === 0) {
+                break;
+            }
+
+            $greaterThanID = $file->ID;
+        }
+    }
+}

--- a/src/FileMigration/FileBinary/Job.php
+++ b/src/FileMigration/FileBinary/Job.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\FileMigration\FileBinary;
+
+use App\Queue;
+use RuntimeException;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class Job extends Queue\Job
+{
+
+    use Queue\ExecutionTime;
+
+    private const TIME_LIMIT = 600;
+
+    public function getTitle(): string
+    {
+        return 'File binary migration job';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        $this->withExecutionTime(self::TIME_LIMIT, function () use ($item): void {
+            $logger = new Queue\Logger();
+            $logger->setJob($this);
+
+            $result = Helper::create()
+                ->setIds([$item])
+                ->setLogger($logger)
+                ->run();
+
+            if ($result) {
+                return;
+            }
+
+            $message = sprintf('File migration failed for file %d', $item);
+
+            if (count($this->items) > 1 || !$this->checkFileBinary($item)) {
+                // suppress exception in case we are migrating a batch or file binary is missing
+                // missing file binaries are not a problem of this migration process
+                // so we don't need to log them as errors
+                $this->addMessage($message);
+
+                return;
+            }
+
+            throw new RuntimeException($message);
+        });
+    }
+
+    private function checkFileBinary(int $id): bool
+    {
+        $query = SQLSelect::create('"Filename"', '"File"', ['"ID"' => $id]);
+        $results = $query->execute();
+        $result = $results->first();
+
+        if (!$result) {
+            return false;
+        }
+
+        $filename = $result['Filename'];
+
+        return file_exists($filename);
+    }
+}

--- a/src/FileMigration/FileBinary/Task.php
+++ b/src/FileMigration/FileBinary/Task.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\FileMigration\FileBinary;
+
+use App\Queue\Factory;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\ValidationException;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 10;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'files-binary-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate file binary migration jobs for all files';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $list = Helper::singleton()
+            ->getFileQuery()
+            ->sort('ID', 'ASC');
+
+        $this->queueJobsFromList($request, $list, Job::class, self::CHUNK_SIZE);
+    }
+}

--- a/src/FileMigration/FixFolderPermission/Job.php
+++ b/src/FileMigration/FixFolderPermission/Job.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\FileMigration\FixFolderPermission;
+
+use App\Queue;
+use SilverStripe\Dev\Tasks\FixFolderPermissionsHelper;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+
+class Job extends AbstractQueuedJob
+{
+
+    public function getTitle(): string
+    {
+        return 'Fix folder permissions job';
+    }
+
+    public function getJobType(): int
+    {
+        return QueuedJob::QUEUED;
+    }
+
+    public function setup(): void
+    {
+        $this->totalSteps = 1;
+    }
+
+    public function process(): void
+    {
+        $logger = new Queue\Logger();
+        $logger->setJob($this);
+
+        $count = FixFolderPermissionsHelper::singleton()
+            ->setLogger($logger)
+            ->run();
+
+        $message = $count > 0
+            ? sprintf('Repaired %s folders with broken CanViewType settings', $count)
+            : 'No folders required fixes';
+
+        $this->addMessage($message);
+        $this->currentStep += 1;
+        $this->isComplete = true;
+    }
+}

--- a/src/FileMigration/FixFolderPermission/Task.php
+++ b/src/FileMigration/FixFolderPermission/Task.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\FileMigration\FixFolderPermission;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\ValidationException;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class Task extends BuildTask
+{
+
+    /**
+     * @var string
+     */
+    private static $segment = 'fix-folder-permission-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate fix folder permission job';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $service = QueuedJobService::singleton();
+        $job = new Job();
+        $service->queueJob($job);
+    }
+}

--- a/src/FileMigration/ImageThumbnail/Helper.php
+++ b/src/FileMigration/ImageThumbnail/Helper.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\FileMigration\ImageThumbnail;
+
+use SilverStripe\AssetAdmin\Helper\ImageThumbnailHelper;
+use SilverStripe\Assets\File;
+
+class Helper extends ImageThumbnailHelper
+{
+
+    public function generateThumbnails(File $file): array
+    {
+        // public scope change
+        return parent::generateThumbnails($file);
+    }
+}

--- a/src/FileMigration/ImageThumbnail/Job.php
+++ b/src/FileMigration/ImageThumbnail/Job.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\FileMigration\ImageThumbnail;
+
+use App\Queue;
+use SilverStripe\AssetAdmin\Helper\ImageThumbnailHelper;
+use SilverStripe\Assets\File;
+
+class Job extends Queue\Job
+{
+
+    use Queue\ExecutionTime;
+
+    private const TIME_LIMIT = 600;
+
+    public function getTitle(): string
+    {
+        return 'Image thumbnail migration job';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    public function setup(): void
+    {
+        $this->remaining = $this->items;
+        $this->totalSteps = count($this->items);
+    }
+
+    /**
+     * Code taken from @see ImageThumbnailHelper::run()
+     *
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        $this->withExecutionTime(self::TIME_LIMIT, function () use ($item): void {
+            /** @var File $file */
+            $file = File::get()->byID($item);
+
+            // Skip if file is not an image
+            if (!$file->getIsImage()) {
+                $this->addMessage(printf('File is not an image: %s', $file->Filename));
+
+                return;
+            }
+
+            $logger = new Queue\Logger();
+            $logger->setJob($this);
+
+            $helper = Helper::create()
+                ->setLogger($logger);
+
+            $generated = $helper->generateThumbnails($file);
+
+            if (count($generated) === 0) {
+                return;
+            }
+
+            $this->addMessage(sprintf('Generated thumbnail for %s', $file->Filename));
+        });
+    }
+}

--- a/src/FileMigration/ImageThumbnail/Task.php
+++ b/src/FileMigration/ImageThumbnail/Task.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\FileMigration\ImageThumbnail;
+
+use App\Queue\Factory;
+use SilverStripe\Assets\Image;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\ValidationException;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 100;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'image-thumbnail-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate image thumbnail migration jobs for all files';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $list = Image::get()->sort('ID', 'ASC');
+        $this->queueJobsFromList($request, $list, Job::class, self::CHUNK_SIZE);
+    }
+}

--- a/src/FileMigration/LegacyThumbnail/Helper.php
+++ b/src/FileMigration/LegacyThumbnail/Helper.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\FileMigration\LegacyThumbnail;
+
+use SilverStripe\Assets\Dev\Tasks\LegacyThumbnailMigrationHelper;
+use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
+use SilverStripe\Assets\Folder;
+use SilverStripe\ORM\DataList;
+
+class Helper extends LegacyThumbnailMigrationHelper
+{
+
+    public function getFolderQuery(): DataList
+    {
+        // public scope change
+        return parent::getFolderQuery();
+    }
+
+    public function migrateFolder(FlysystemAssetStore $store, Folder $folder): array
+    {
+        // public scope change
+        return parent::migrateFolder($store, $folder);
+    }
+}

--- a/src/FileMigration/LegacyThumbnail/Job.php
+++ b/src/FileMigration/LegacyThumbnail/Job.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\FileMigration\LegacyThumbnail;
+
+use App\Queue;
+use RuntimeException;
+use SilverStripe\Assets\Dev\Tasks\LegacyThumbnailMigrationHelper;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Core\Environment;
+use SilverStripe\Versioned\Versioned;
+
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Legacy thumbnail migration job';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * Code taken from @see LegacyThumbnailMigrationHelper::run()
+     *
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        // Set max time and memory limit
+        Environment::increaseTimeLimitTo();
+        Environment::setMemoryLimitMax(-1);
+        Environment::increaseMemoryLimitTo(-1);
+
+        Versioned::withVersionedMode(function () use ($item): void {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            $logger = new Queue\Logger();
+            $logger->setJob($this);
+
+            $folder = $item
+                ? File::get()->byID($item)
+                : Folder::create();
+
+            if ($folder === null) {
+                throw new RuntimeException(sprintf('Legacy folder not found for file %d', $item));
+            }
+
+            $result = Helper::create()
+                ->setLogger($logger)
+                ->migrateFolder(singleton(AssetStore::class), $folder);
+
+            if (count($result) > 0) {
+                return;
+            }
+
+            $this->addMessage(sprintf('Nothing moved for folder for file %d', $item));
+        });
+    }
+}

--- a/src/FileMigration/LegacyThumbnail/Task.php
+++ b/src/FileMigration/LegacyThumbnail/Task.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\FileMigration\LegacyThumbnail;
+
+use App\Queue\Factory;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\Versioned;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 20;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'legacy-thumbnail-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate legacy thumbnail migration job for all folders';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $ids = $this->getItemsToProcess();
+        $this->queueJobsFromIds($request, $ids, Job::class, self::CHUNK_SIZE);
+    }
+
+    /**
+     * Code taken from @see LegacyThumbnailMigrationHelper::run()
+     *
+     * @return array
+     */
+    private function getItemsToProcess(): array
+    {
+        // Check if the File dataobject has a "Filename" field.
+        // If not, cannot migrate
+        if (!DB::get_schema()->hasField('File', 'Filename')) {
+            return [];
+        }
+
+        return Versioned::withVersionedMode(static function (): array {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            // we start with just the root folder
+            $ids = [0];
+
+            // Migrate all nested folders
+            $folders = Helper::create()
+                ->getFolderQuery()
+                ->sort('ID', 'ASC')
+                ->columnUnique('ID');
+
+            foreach ($folders as $id) {
+                if (!$id) {
+                    continue;
+                }
+
+                $ids[] = (int) $id;
+            }
+
+            return $ids;
+        });
+    }
+}

--- a/src/FileMigration/SecureAssets/Helper.php
+++ b/src/FileMigration/SecureAssets/Helper.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\FileMigration\SecureAssets;
+
+use League\Flysystem\Filesystem;
+use SilverStripe\Assets\Dev\Tasks\SecureAssetsMigrationHelper;
+
+class Helper extends SecureAssetsMigrationHelper
+{
+
+    public function migrateFolder(Filesystem $filesystem, $path) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        // public scope change
+        return parent::migrateFolder($filesystem, $path);
+    }
+}

--- a/src/FileMigration/SecureAssets/Job.php
+++ b/src/FileMigration/SecureAssets/Job.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\FileMigration\SecureAssets;
+
+use App\Queue;
+use SilverStripe\Assets\Dev\Tasks\SecureAssetsMigrationHelper;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Secure assets migration job';
+    }
+
+    public function setup(): void
+    {
+        $this->items = $this->getItemsToProcess();
+
+        parent::setup();
+    }
+
+    /**
+     * Code taken from @see SecureAssetsMigrationHelper::run()
+     *
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        $logger = new Queue\Logger();
+        $logger->setJob($this);
+
+        $helper = Helper::create()
+            ->setLogger($logger);
+
+        /** @var Folder $folder */
+        $folder = Folder::get()->byID($item);
+
+        if (!$folder) {
+            $this->addMessage(sprintf('No Folder record found for ID %d. Skipping', $item));
+
+            return;
+        }
+
+        $store = singleton(AssetStore::class);
+        $filesystem = $store->getPublicFilesystem();
+
+        $result = $helper->migrateFolder($filesystem, $folder->getFilename());
+
+        if ($result) {
+            return;
+        }
+
+        $this->addMessage(sprintf('No action needed for Folder ID %d. Skipping', $item));
+    }
+
+    /**
+     * Code taken from @see SecureAssetsMigrationHelper::run()
+     *
+     * @return array
+     */
+    private function getItemsToProcess(): array
+    {
+        $fileTable = DataObject::getSchema()->baseDataTable(File::class);
+        $securedFolders = SQLSelect::create()
+            ->setFrom(sprintf('"%s"', $fileTable))
+            ->setSelect([
+                '"ID"',
+                '"FileFilename"',
+            ])
+            ->addWhere([
+                '"ClassName" = ?' => Folder::class,
+                // We don't need to check 'Inherited' permissions,
+                // since Apache applies parent .htaccess and the module doesn't create them in this case.
+                // See SecureFileExtension->needsAccessFile()
+                '"CanViewType" IN(?,?)' => ['LoggedInUsers', 'OnlyTheseUsers'],
+            ]);
+
+        $items = [];
+
+        foreach ($securedFolders->execute()->map() as $id => $path) {
+            if (!$id) {
+                continue;
+            }
+
+            $items[] = (int) $id;
+        }
+
+        return $items;
+    }
+}

--- a/src/FileMigration/SecureAssets/Task.php
+++ b/src/FileMigration/SecureAssets/Task.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\FileMigration\SecureAssets;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\ValidationException;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class Task extends BuildTask
+{
+
+    /**
+     * @var string
+     */
+    private static $segment = 'secure-assets-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate secure assets job';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $service = QueuedJobService::singleton();
+        $job = new Job();
+        $service->queueJob($job);
+    }
+}

--- a/src/FileMigration/TagsToShortCode/Helper.php
+++ b/src/FileMigration/TagsToShortCode/Helper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\FileMigration\TagsToShortCode;
+
+use SilverStripe\Assets\Dev\Tasks\TagsToShortcodeHelper;
+use SilverStripe\Assets\File;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class Helper extends TagsToShortcodeHelper
+{
+
+    /**
+     * Copy of code from @see TagsToShortcodeHelper::updateTable()
+     *
+     * The full text search condition got replaced with ID condition
+     *
+     * @param string $table
+     * @param string $field
+     * @param array $ids
+     */
+    public function updateTable(string $table, string $field, array $ids): void
+    {
+        if (count($ids) === 0) {
+            return;
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+
+        $query = SQLSelect::create(
+            ['"ID"', sprintf('"%s"', $field)],
+            sprintf('"%s"', $table),
+            ['"ID" IN (' . $placeholders . ')' => $ids]
+        );
+
+        $records = $query->execute();
+        $this->rewriteFieldForRecords($records, $table, $field);
+    }
+
+    public function getFieldMap(// phpcs:ignore SlevomatCodingStandard.TypeHints
+        $baseClass,
+        $includeBaseClass,
+        $fieldNames
+    ): array {
+        // public scope change
+        return parent::getFieldMap($baseClass, $includeBaseClass, $fieldNames);
+    }
+
+    /**
+     * Override for @see TagsToShortcodeHelper::updateTagFromFile()
+     *
+     * Remove empty attributes
+     * this remedies the issue with WYSIWYG editor not rendering assets with empty attribute
+     *
+     * @param string $tag
+     * @param File $file
+     * @return string
+     */
+    protected function updateTagFromFile($tag, File $file)// phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        return str_replace(['title=""', 'alt=""'], ['', ''], $tag);
+    }
+}

--- a/src/FileMigration/TagsToShortCode/Job.php
+++ b/src/FileMigration/TagsToShortCode/Job.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\FileMigration\TagsToShortCode;
+
+use App\Queue;
+use SilverStripe\Assets\Dev\Tasks\TagsToShortcodeHelper;
+
+/**
+ * Class Job
+ *
+ * @property string $table
+ * @property string $field
+ * @package App\FileMigration\TagsToShortCode
+ */
+class Job extends Queue\Job
+{
+
+    public function getTitle(): string
+    {
+        return 'Tags to short code migration job';
+    }
+
+    public function hydrate(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * Code taken from @see TagsToShortcodeHelper::run()
+     *
+     * @param mixed $item
+     */
+    protected function processItem($item): void
+    {
+        $table = array_shift($item);
+        $field = array_shift($item);
+        $id = array_shift($item);
+
+        $logger = new Queue\Logger();
+        $logger->setJob($this);
+
+        $helper = Helper::create();
+        $helper->setLogger($logger);
+
+        // Update table
+        $helper->updateTable($table, $field, [$id]);
+    }
+}

--- a/src/FileMigration/TagsToShortCode/Legacy/Helper.php
+++ b/src/FileMigration/TagsToShortCode/Legacy/Helper.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\FileMigration\TagsToShortCode\Legacy;
+
+use SilverStripe\Assets\FilenameParsing\LegacyFileIDHelper;
+use SilverStripe\Assets\FilenameParsing\ParsedFileID;
+
+/**
+ * Class Helper
+ *
+ * Custom functionality which implements SS 3.0 assets legacy format migration which is not covered out of the box
+ *
+ * @package App\FileMigration\TagsToShortCode\Legacy
+ */
+class Helper extends LegacyFileIDHelper
+{
+
+    /**
+     * Override for @see LegacyFileIDHelper::parseLegacyFormat()
+     *
+     * @param string $fileID
+     * @param string $variant
+     * @param string $folder
+     * @param string $filename
+     * @param string $extension
+     * @return ParsedFileID|null
+     */
+    protected function parseLegacyFormat(// phpcs:ignore SlevomatCodingStandard.TypeHints
+        $fileID,
+        $variant,
+        $folder,
+        $filename,
+        $extension
+    ) {
+        $variant = trim($variant);
+
+        if (!$variant || !$folder || !$filename || !$extension) {
+            return null;
+        }
+
+        // extract first variant, the rest will be treated as a part of the filename
+        $segments = explode('-', $variant);
+        $segments = array_diff($segments, ['']);
+        $realVariant = array_shift($segments) . '-';
+        $prefix = str_replace($realVariant, '', $variant);
+        $filename = $folder . $prefix . $filename . $extension;
+
+        return new ParsedFileID($filename, '', '', $fileID);
+    }
+}

--- a/src/FileMigration/TagsToShortCode/Legacy/Strategy.php
+++ b/src/FileMigration/TagsToShortCode/Legacy/Strategy.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\FileMigration\TagsToShortCode\Legacy;
+
+use League\Flysystem\Filesystem;
+use SilverStripe\Assets\FilenameParsing\FileIDHelperResolutionStrategy;
+use SilverStripe\Assets\FilenameParsing\ParsedFileID;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class Strategy extends FileIDHelperResolutionStrategy
+{
+
+    /**
+     * Code taken from @see FileIDHelperResolutionStrategy::resolveFileID()
+     *
+     * @param string $fileID
+     * @param Filesystem $filesystem
+     * @return ParsedFileID|null
+     */
+    public function resolveFileID($fileID, Filesystem $filesystem) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        foreach ($this->getResolutionFileIDHelpers() as $fileIDHelper) {
+            $parsedFileID = $fileIDHelper->parseFileID($fileID);
+
+            if (!$parsedFileID) {
+                continue;
+            }
+
+            $filename = $parsedFileID->getFilename();
+            $filename = $this->fixFilename($filename);
+            $parsedFileID = $parsedFileID->setFilename($filename);
+
+            $foundTuple = $this->searchForTuple($parsedFileID, $filesystem, true);
+
+            if ($foundTuple) {
+                return $foundTuple;
+            }
+        }
+
+        // If we couldn't resolve the file ID, we bail
+        return null;
+    }
+
+    /**
+     * Fetch correct filename from database instead of relying on filename from asset reference
+     * this fixes case sensitivity errors
+     *
+     * @param string $filename
+     * @return string
+     */
+    private function fixFilename(string $filename): string
+    {
+        if (!$filename) {
+            return $filename;
+        }
+
+        $query = SQLSelect::create(
+            '"FileFilename"',
+            '"File"',
+            sprintf('LCASE("FileFilename") = %s', Convert::raw2sql(mb_strtolower($filename), true)),
+            ['"ID"' => 'ASC'],
+            [],
+            [],
+            1
+        );
+
+        $results = $query->execute();
+        $result = $results->first();
+
+        if (!array_key_exists('FileFilename', $result) || !$result['FileFilename']) {
+            return $filename;
+        }
+
+        return (string) $result['FileFilename'];
+    }
+}

--- a/src/FileMigration/TagsToShortCode/Task.php
+++ b/src/FileMigration/TagsToShortCode/Task.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\FileMigration\TagsToShortCode;
+
+use App\Queue\Factory;
+use ReflectionException;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Environment;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\Versioned;
+
+class Task extends Factory\Task
+{
+
+    private const CHUNK_SIZE = 10;
+
+    /**
+     * @var string
+     */
+    private static $segment = 'tags-to-short-code-migration-task';
+
+    public function getDescription(): string
+    {
+        return 'Generate tags to short code migration job';
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @throws ValidationException
+     * @throws ReflectionException
+     */
+    public function run($request): void // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $fields = $this->getTableFields();
+        $items = [];
+
+        foreach ($fields as $data) {
+            $table = array_shift($data);
+            $field = array_shift($data);
+
+            $query = SQLSelect::create('"ID"', sprintf('"%s"', $table), [], ['ID' => 'ASC']);
+            $results = $query->execute();
+
+            while ($result = $results->next()) {
+                $id = (int) $result['ID'];
+                $items[] = [
+                    $table,
+                    $field,
+                    $id,
+                ];
+            }
+        }
+
+        $this->queueJobsFromData($request, $items, Job::class, self::CHUNK_SIZE);
+    }
+
+    /**
+     * Code taken from @see TagsToShortcodeHelper::run()
+     *
+     * @return array
+     * @throws ReflectionException
+     */
+    private function getTableFields(): array
+    {
+        $helper = Helper::create();
+        Environment::increaseTimeLimitTo();
+
+        $classes = $helper->getFieldMap(DataObject::class, false, [
+            'HTMLText',
+            'HTMLVarchar',
+        ]);
+
+        $versioned = singleton(Versioned::class);
+        $tableList = DB::table_list();
+        $items = [];
+
+        foreach ($classes as $class => $tables) {
+            /** @var DataObject|Versioned $singleton */
+            $singleton = singleton($class);
+            $hasVersions =
+                $singleton->hasExtension(Versioned::class) &&
+                $singleton->hasStages();
+
+            foreach ($tables as $table => $fields) {
+                foreach ($fields as $field) {
+
+                    /** @var DBField $dbField */
+                    $dbField = DataObject::singleton($class)->dbObject($field);
+
+                    if ($dbField &&
+                        $dbField->hasMethod('getProcessShortcodes') &&
+                        !$dbField->getProcessShortcodes()) {
+                        continue;
+                    }
+
+                    if (!isset($tableList[strtolower($table)])) {
+                        // When running unit test some tables won't be created. We'll just skip those.
+                        continue;
+                    }
+
+                    $items[] = [
+                        $table,
+                        $field,
+                    ];
+
+                    if (!$hasVersions) {
+                        continue;
+                    }
+
+                    $items[] = [
+                        $versioned->stageTable($table, Versioned::LIVE),
+                        $field,
+                    ];
+                }
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Report/CorruptedAssetsReport.php
+++ b/src/Report/CorruptedAssetsReport.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Report;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Reports\Report;
+use SilverStripe\Versioned\Versioned;
+
+class CorruptedAssetsReport extends Report
+{
+
+    /**
+     * @var string
+     */
+    protected $title = 'Corrupted assets';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Find all assets which failed migration';
+
+    public function sourceRecords(// phpcs:ignore SlevomatCodingStandard.TypeHints
+        array $params = [],
+        $sort = null,
+        $limit = null
+    ): SS_List {
+        return Versioned::withVersionedMode(static function () use ($sort, $limit): SS_List {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            $list = DataObject::get(File::class, null, $sort, null, $limit);
+
+            return $list
+                ->filter('FileHash', null)
+                ->exclude('ClassName', Folder::class);
+        });
+    }
+
+    public function columns(): array
+    {
+        return [
+            'ID' => [
+                'title' => 'ID',
+                'formatting' => '$ID',
+            ],
+            'Title' => [
+                'title' => 'Asset name',
+                'link' => static function ($value, $item) {
+                    /** @var File $item */
+                    return sprintf(
+                        '<a class="grid-field__link-block" href="%s" title="%s" target="_blank">%s</a>',
+                        Convert::raw2att($item->CMSEditLink()),
+                        Convert::raw2att($value),
+                        Convert::raw2xml($value)
+                    );
+                },
+            ],
+        ];
+    }
+}

--- a/src/Report/LegacyAssetsReport.php
+++ b/src/Report/LegacyAssetsReport.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Report;
+
+use SilverStripe\CMS\Model\RedirectorPage;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Reports\Report;
+
+class LegacyAssetsReport extends Report
+{
+
+    private const HTML_FIELDS = [
+        [
+            'Page',
+            'Abstract',
+        ],
+        [
+            'VacancyLandingPage',
+            'VancancyFooter',
+        ],
+        [
+            'PageSection',
+            'Content',
+        ],
+        [
+            'SiteTree',
+            'Content',
+        ],
+    ];
+
+    private const QUERIES = [
+        // image tags which failed to migrate
+        'SELECT "ID" FROM "%1$s" WHERE "%2$s" REGEXP \'<img[^>]* src="assets/\'',
+        // resampled assets references (debug only as this is a subset of the image tags)
+//        'SELECT "ID" FROM "%1$s" WHERE "%2$s" LIKE \'%%_resampled/ResizedImage%%\''
+//        . ' AND "%2$s" REGEXP \'(_resampled\/ResizedImage)+[a-zA-Z0-9]+[-]{1}\''
+//        . ' AND "%2$s" NOT REGEXP \'(_resampled\/ResizedImage)+[a-zA-Z0-9]+[\/]{1}\'',
+        // image shortcodes with empty attribute (debug only as this is a subset of the image tags)
+//        'SELECT "ID" FROM "%1$s" WHERE "%2$s" REGEXP \'[[]image[^]]*=""[^]]*[]]\'',
+    ];
+
+    public function title(): string
+    {
+        return 'Legacy asset references';
+    }
+
+    public function sourceRecords( // phpcs:ignore SlevomatCodingStandard.TypeHints
+        array $params = [],
+        $sort = null,
+        $limit = null
+    ): SS_List {
+        $ids = [];
+
+        foreach (self::HTML_FIELDS as $fieldData) {
+            $table = array_shift($fieldData);
+            $field = array_shift($fieldData);
+
+            foreach (self::QUERIES as $sql) {
+                $query = sprintf($sql, $table, $field);
+                $results = DB::query($query);
+
+                while ($result = $results->next()) {
+                    $id = (int) $result['ID'];
+
+                    if (!$id) {
+                        continue;
+                    }
+
+                    $ids[$id] = $id;
+                }
+            }
+        }
+
+        $list = DataObject::get(SiteTree::class, null, $sort, null, $limit);
+
+        if (count($ids) === 0) {
+            return $list->byIDs([0]);
+        }
+
+        if ($sort === null) {
+            $list = $list->sort('ID', 'ASC');
+        }
+
+        return $list
+            ->exclude([
+                'ClassName' => RedirectorPage::class,
+            ])
+            ->filter([
+                'ID' => array_values($ids),
+            ]);
+    }
+
+    public function columns(): array
+    {
+        return [
+            'ID' => [
+                'title' => 'ID',
+                'formatting' => '$ID',
+            ],
+            'Type' => [
+                'title' => 'Type',
+                'link' => static function ($value, $item) {
+                    return ClassInfo::shortName($item);
+                },
+            ],
+            'State' => [
+                'title' => 'State',
+                'link' => static function ($value, $item) {
+                    /** @var $item SiteTree */
+                    if (!$item instanceof SiteTree) {
+                        return 'Not published';
+                    }
+
+                    return $item->isPublished()
+                        ? 'Published'
+                        : 'Not published';
+                },
+            ],
+            'Title' => [
+                'title' => 'Page title',
+                'formatting' =>
+                    '<a href=\"admin/pages/edit/show/$ID\" title=\"Edit page\" target=\"_blank\">$value</a>',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# SilverStripe 3.x to 4.5.x migration toolkit for at least medium sized projects

## Disclaimer

This pull request serves as a preview for features which can be imported into this module. Feature code is included as is from the bespoke project (it's serving as reference only). It's already well organised for module import as it contains no bespoke code dependencies unless stated in the documentation.

The goal here is to review each feature and determine if effort is worth putting into moving this feature to the module. Features identified as "worth the effort" will be separated into their own pull request which follows standard review flow.

Please `DO NOT` code review this PR. The code is not meant to be merged, only reviewed on **do we want this feature in the module or not** basis.

## Summary

Migrating assets from `3.x` to `4.5.x` can be challenging if the project size is significant enough. This toolkit provides solutions for migration of such projects without changing any exisiting migration functionality. Instead, the approach here is to:

* bundle existing migration work into smaller, easier to process and more transparent batches
* speed up the migration process by supporting parallel processing
* add support for use cases which were left out
* we recognise that the goal of automated migration isn't to cover 100% of the cases, for such situations we need some CMS reports which make the inevitable manual content fixes by content authors easier

## Dependencies

* [Queue fixes / setup](https://github.com/symbiote/silverstripe-queuedjobs/pull/290)
* [Minor asset module tweaks](https://github.com/silverstripe/silverstripe-assets/pull/396/commits/f7294dfa08cee3e645a1728c3049abe4f48d2d0c)

## Test setup

* medium sized project
* `16 000` pages (of which `7 000` published pages)
* `28 000` assets (of which `2 000` folders)
* `50` GB asset size on disc
* shallow nesting structure (few nested objects, publish recursive executes reasonably fast)
* heavy use of HTML fields and asset references
* assets are setup to publish when page publishes (via `owns` and via `file tracking`)
* all published pages forced to publish as a part of the upgrade process
* queue parallel ratio: up to `10` jobs at the same time (depends on type of job)
* total duration of upgrade process: `28` hours

## List of features / fixes included in this bundle

This is the full list of features / fixes with details explaining why this feature is needed or what problem is it trying to solve. Features will be numbered for quick reference but the list is in arbitrary order.

### Feature 1 - Queued jobs wrapper for migration dev tasks

#### Problem

* unable or unwilling to run dev task on PROD as is requires CLI access to an instance
* running single large dev task is risky as the processing may fail for many reasons during the execution (most notable ones are DB deadlocks or EFS issues which go away after retry)
* task has to be manually restarted each time it fails, constant monitoring required
* there is no transparency on the overall progress
* little visibility on issues related to individual items
* no possibility of safe parallel execution to speed up the whole process
* dev task executed as a job has similar issues as well as dev task executed via browser

#### Solution

* provide a thread safe queued job wrapper for the dev task functionality (one piece of work is executed at most once at any given time, avoid DB deadlocks for example)
* instead of a single large task, split the work into many small jobs which support progress indication (steps) and automatic restart / resume attempts (more automation = less monitoring)
* log any individual asset related issues into the job itself (easier debugging)
* creating of jobs is much faster than actual execution which means that the developer time needed to babysit the upgrade process is reduced significantly
* parallel processing supported, for example sequential run via dev task of `Part 1 MigrateFileTask / move-files` would take `32` hours, but parallel run via queued jobs takes only `11` hours

Major win of this approach allows the developer to create a lot of migration work in matter of seconds which will keep the queue busy for dozens of hours. For example, on this test project the developer can run three migration related dev tasks one after another which will keep the queue processing for 20 hours and during this time no monitoring is required as everything is run through jobs. Job progression is much easier to track as the number of completed jobs is a very good indication of progress.

This solution is applied to all parts of the migration.

##### Part 1: MigrateFileTask / move-files

* migration functionality change: process only a one asset at a time
* high potential to run in parallel
* code reference `App\FileMigration\FileBinary`

##### Part 2: MigrateFileTask / migrate-folders

* migration functionality is a bespoke solution for this part which is roughly the same as the solution which was later introduced in `4.5.2` by the product team
* the only notable difference is that this solution will process only one folder at a time
* low potential to run in parallel
* code reference `App\BatchPublish\Folder`

##### Part 3: MigrateFileTask / move-thumbnails

* migration functionality change: process only a one folder at a time
* some potential to run in parallel
* code reference `App\FileMigration\LegacyThumbnail`

##### Part 4: MigrateFileTask / generate-cms-thumbnails

* migration functionality change: process only a one image at a time
* high potential to run in parallel
* code reference `App\FileMigration\ImageThumbnail`

##### Part 5: MigrateFileTask / fix-folder-permissions

* migration functionality change: wrap the whole process inside one single-step job
* no potential to run in parallel
* code reference `App\FileMigration\FixFolderPermission`

##### Part 6: MigrateFileTask / fix-secureassets

* migration functionality change: wrap the whole process inside one job which will process one folder at a time
* no potential to run in parallel
* code reference `App\FileMigration\SecureAssets`

##### Part 7: TagsToShortcodeTask

* migration functionality change: process only one field of one record of one table at a time
* high potential to run in parallel
* code reference `App\FileMigration\TagsToShortCode`
* empty HTML attributes are deleted as they break the HTML editor UI
* added support for legacy asset reference format as this html asset reference format will not be migrated by default, for example `ResizedImage480285-GeogL191014.png`
* added support for case-sensitivity file name variants as html asset reference which doesn't exactly match the filename will not be migrated by default (can't reproduce on local), for example `qualifications-and-standards/qualifications/ncea/NCEA-cartoon-screen1.gif` vs `Qualifications-and-standards/Qualifications/NCEA/NCEA-cartoon-screen1.gif`
* assumes that there are no two assets with case variation of the same filename, i.e. following query yields no results:

```
SELECT LCASE(`FileFilename`) as `l_name`, COUNT(`ID`) as `count` FROM `File` WHERE `FileFilename` IS NOT NULL GROUP BY `l_name` HAVING `count` > 1
```

### Feature 2 - Failed migration for assets report

#### Problem

* It's difficult to understand which assets failed migration
* the migration dev task provides an output but this is not that helpful when general overview report is needed
* it's fine not to migrate all assets automatically, but we need to provide a CMS report so content authors can apply manual fixes where needed

#### Solution

CMS viewable report of all assets which failed to migrate. This is a standard CMS report with no UI customisation.

![Screen Shot 2020-08-19 at 7 44 11 AM](https://user-images.githubusercontent.com/26395487/90558308-f9a51380-e1ef-11ea-8e5f-6a6a51591a3f.png)

#### Code reference

`App\Report\CorruptedAssetsReport`

### Feature 3 - Failed migration for asset HTML references report

#### Problem

* it's difficult to track down all pages which have asset HTML references which failed to migrate
* the migration dev task provides an output but this is not that helpful when general overview report is needed
* it's fine not to migrate all asset HTML references automatically, but we need to provide a CMS report so content authors can apply manual fixes where needed

#### Solution

CMS viewable report of all asset HTML references which failed to migrate. This is a standard CMS report with no UI customisation.

![Screen Shot 2020-08-19 at 7 44 27 AM](https://user-images.githubusercontent.com/26395487/90558339-09245c80-e1f0-11ea-83c6-fe6559f48349.png)

#### Code reference

`App\Report\LegacyAssetsReport`

### Feature 4 - Batch page publish

#### Problem

* some pages are missing version history
* some pages need to regenerate some static files (after publish)
* some pages require publish validation (for example a page is not allowed to be placed under specific page type)
* some pages may have nested objects which need publishing after upgrade
* sometimes there is a requirement to have a version history record which represents the upgrade changes

#### Solution

* batch publish for all published pages (force new version history record)
* use queued jobs to allow thread safe solution which supports automatic retries and checkpoints

#### Code reference

`App\BatchPublish\Page`

### Feature 5 - Batch asset publish

#### Problem

* it may be handy to have the option to publish all assets which partially validates if upgrade migration was successful
* note that this is not necessary if assets are getting automatically published as a part of page publishing process

#### Solution

* batch publish for all assets (force new version history record)
* use queued jobs to allow thread safe solution which supports automatic retries and checkpoints

#### Code reference

`App\BatchPublish\Asset`

### Feature 6 - Publish recursive setup

#### Problem

* out of the box behaviour for asset publishing is inconsistent
* assets used via HTML fields will get published when page gets published by default
* assets used via relations will NOT get published when page gets published by default

#### Solution

* improve documentation on how to use `owns`, `owned_by`
* these configurations are new in SS `4.x` and need to be added as a part of the upgrade
* suggestion: add this to upgrade [gotchas doc](https://silverstripe.atlassian.net/wiki/spaces/BT/blog/2018/11/22/719683680/SilverStripe+4+-+Upgrade+Gotchas)

### Feature 7 - Recursive operations setup

#### Problem

* out of the box behaviour for recursive copy and delete will not work as expected by default
* note that out of the box functionality of the CMS allows Page duplication action
* this will not work properly without proper configuration

#### Solution

* improve documentation on how to use `cascade_duplicates`, `cascade_deletes`
* these configurations are new in SS `4.x` and need to be added as a part of the upgrade
* suggestion: add this to upgrade [gotchas doc](https://silverstripe.atlassian.net/wiki/spaces/BT/blog/2018/11/22/719683680/SilverStripe+4+-+Upgrade+Gotchas)