### PR TITLE
Fix image grant policy

### DIFF
--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -52,8 +52,9 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
             /** @var AssetStore $store */
             $store = Injector::inst()->get(AssetStore::class);
             if (!empty($item['filename'])) {
+                $grant = static::config()->allow_session_grant;
                 // Initiate a protected asset grant if necessary
-                $store->getAsURL($item['filename'], $item['hash']);
+                $store->getAsURL($item['filename'], $item['hash'], null, $grant);
             }
             return $item['markup'];
         }


### PR DESCRIPTION
Align the logic for anonymous access to images with the logic for documents.
Fixes https://github.com/silverstripe/silverstripe-assets/issues/220