### PR TITLE
FIX Ensure session grant config is respected on uncached file shortcodes

### DIFF
--- a/src/Dev/TestAssetStore.php
+++ b/src/Dev/TestAssetStore.php
@@ -18,9 +18,11 @@ use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 
 /**
@@ -192,6 +194,17 @@ class TestAssetStore extends FlysystemAssetStore implements TestOnly
     public function getDefaultConflictResolution($variant)
     {
         return parent::getDefaultConflictResolution($variant);
+    }
+
+    /**
+     * Allows testing of grant status
+     *
+     * @param string $filename
+     * @param string $hash
+     */
+    public function isGranted($fileID)
+    {
+        return parent::isGranted($fileID);
     }
 
     protected function isSeekableStream($stream)

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -73,17 +73,19 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
      */
     public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = [])
     {
+        $allowSessionGrant = static::config()->allow_session_grant;
+
         /** @var CacheInterface $cache */
         $cache = static::getCache();
         $cacheKey = static::getCacheKey($arguments, $content);
 
         $item = $cache->get($cacheKey);
         if ($item) {
-            /** @var AssetStore $store */
-            $store = Injector::inst()->get(AssetStore::class);
             if (!empty($item['filename'])) {
-                $grant = static::config()->allow_session_grant;
-                $store->getAsURL($item['filename'], $item['hash'], null, $grant);
+                /** @var AssetStore $store */
+                $store = Injector::inst()->get(AssetStore::class);
+
+                $store->getAsURL($item['filename'], $item['hash'], null, $allowSessionGrant);
             }
             return $item['markup'];
         }
@@ -99,10 +101,13 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
             return null; // There were no suitable matches at all.
         }
 
+        // Retrieve the file URL (ensuring session grant config is respected)
+        $url = $record->getURL($allowSessionGrant);
+
         // build the HTML tag
         if ($content) {
             // build some useful meta-data (file type and size) as data attributes
-            $attrs = [ 'href' => $record->Link() ];
+            $attrs = [ 'href' => $url ];
             if ($record instanceof File) {
                 $attrs = array_merge($attrs, [
                      'class' => 'file',
@@ -112,7 +117,7 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
             }
             $markup = HTML::createTag('a', $attrs, $parser->parse($content));
         } else {
-            $markup = $record->Link();
+            $markup = $url;
         }
 
         // cache it for future reference

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -81,12 +81,11 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
 
         $item = $cache->get($cacheKey);
         if ($item) {
-            if (!empty($item['filename'])) {
-                /** @var AssetStore $store */
-                $store = Injector::inst()->get(AssetStore::class);
-
-                $store->getAsURL($item['filename'], $item['hash'], null, $allowSessionGrant);
+            // Initiate a protected asset grant if necessary
+            if (!empty($item['filename']) && $allowSessionGrant) {
+                Injector::inst()->get(AssetStore::class)->grant($item['filename'], $item['hash']);
             }
+
             return $item['markup'];
         }
 

--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -44,6 +44,8 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
      */
     public static function handle_shortcode($args, $content, $parser, $shortcode, $extra = [])
     {
+        $allowSessionGrant = static::config()->allow_session_grant;
+
         $cache = static::getCache();
         $cacheKey = static::getCacheKey($args);
 
@@ -52,9 +54,8 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
             /** @var AssetStore $store */
             $store = Injector::inst()->get(AssetStore::class);
             if (!empty($item['filename'])) {
-                $grant = static::config()->allow_session_grant;
                 // Initiate a protected asset grant if necessary
-                $store->getAsURL($item['filename'], $item['hash'], null, $grant);
+                $store->getAsURL($item['filename'], $item['hash'], null, $allowSessionGrant);
             }
             return $item['markup'];
         }
@@ -71,7 +72,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
         }
 
         // Check if a resize is required
-        $src = $record->Link();
+        $src = $record->getURL($allowSessionGrant);
         if ($record instanceof Image) {
             $width = isset($args['width']) ? $args['width'] : null;
             $height = isset($args['height']) ? $args['height'] : null;
@@ -80,7 +81,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
                 $resized = $record->ResizedImage($width, $height);
                 // Make sure that the resized image actually returns an image
                 if ($resized) {
-                    $src = $resized->getURL();
+                    $src = $resized->getURL($allowSessionGrant);
                 }
             }
         }

--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -51,12 +51,11 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
 
         $item = $cache->get($cacheKey);
         if ($item) {
-            /** @var AssetStore $store */
-            $store = Injector::inst()->get(AssetStore::class);
-            if (!empty($item['filename'])) {
-                // Initiate a protected asset grant if necessary
-                $store->getAsURL($item['filename'], $item['hash'], null, $allowSessionGrant);
+            // Initiate a protected asset grant if necessary
+            if (!empty($item['filename']) && $allowSessionGrant) {
+                Injector::inst()->get(AssetStore::class)->grant($item['filename'], $item['hash']);
             }
+
             return $item['markup'];
         }
 


### PR DESCRIPTION
Supplementary fix for CVE-2019-14273, adjusting the logic to ensure that the `FileShortcodeProvider::$allow_session_grant config` is still applied when a shortcode is uncached.

`File::Link()` should not be used unless the user _must_ be guaranteed access to the asset and the security implications are sufficiently considered and mitigated.

Fixes #220.