### PR TITLE
Allow file variant with different extensions POC

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1503,4 +1503,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     {
         return FileNameFilter::create();
     }
+
+
+    public function ToImage(): ?AssetContainer
+    {
+        return $this->File->ToImage();
+    }
 }

--- a/src/FilenameParsing/AlternativeFileExtensionTrait.php
+++ b/src/FilenameParsing/AlternativeFileExtensionTrait.php
@@ -4,46 +4,77 @@ namespace SilverStripe\Assets\FilenameParsing;
 
 use SilverStripe\Core\Convert;
 
+/**
+ * This trait can be applied to a `FileIDHelper` imlementation to add the baility to encode alternative file extension.
+ *
+ * This allows the creation of file variant with different extension to the original file.
+ */
 trait AlternativeFileExtensionTrait
 {
 
+    /**
+     * Rewrite a filename with a different extension
+     * @param string $filename
+     * @param string $variant
+     * @return string
+     */
     public function rewriteVariantExtension(string $filename, string $variant): string
     {
         return $this->swapExtension($filename, $variant, 1);
     }
 
+    /**
+     * Rewrite a filename to use the original extension for the provided variant.
+     * @param string $filename
+     * @param string $variant
+     * @return string
+     */
     public function restoreOriginalExtension(string $filename, string $variant): string
     {
         return $this->swapExtension($filename, $variant, 0);
     }
 
+    /**
+     * Construct the original or alternative filname extension for the given filename and variant string.
+     * @param string $filename Original filename without variant
+     * @param string $variant Full variant list
+     * @param int $extIndex Wether we want the original extension (0) or the new extension (1)
+     * @return string
+     */
     private function swapExtension(
         string $filename,
         string $variant,
         int $extIndex
-    ): string
-    {
+    ): string {
+        // If there's no variant at all, we can rewrite the filenmane
         if (empty($variant)) {
             return $filename;
         }
 
+        // Split variant string in variant list
         $subVariants = explode('_', $variant);
 
+        // Split our filename into a filename and extension part
         if (!preg_match('/(.+)\.([a-z\d]+)$/i', $filename, $matches)) {
             return $filename;
         }
-
         [$_, $filenameWitoutExtension, $extension] = $matches;
 
+        // Loop our variant list until we find our special file extension swap variant
         foreach ($subVariants as $subVariant) {
-            if (preg_match("/^extRewrite(.+)$/", $subVariant, $matches)) {
+            $extSwapVariant = FileIDHelper::EXTENSION_REWRITE_VARIANT;
+            if (preg_match("/^$extSwapVariant(.+)$/", $subVariant, $matches)) {
                 [$_, $base64] = $matches;
+
+                /**
+                 * This array always contain 2 values: The orignial extension and the new extension
+                 * @var array $extensionData
+                 */
                 $extensionData = Convert::base64url_decode($base64);
                 $extension = $extensionData[$extIndex];
             }
         }
 
         return $filenameWitoutExtension . '.' . $extension;
-
     }
 }

--- a/src/FilenameParsing/AlternativeFileExtensionTrait.php
+++ b/src/FilenameParsing/AlternativeFileExtensionTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SilverStripe\Assets\FilenameParsing;
+
+use SilverStripe\Core\Convert;
+
+trait AlternativeFileExtensionTrait
+{
+
+    public function rewriteVariantExtension(string $filename, string $variant): string
+    {
+        return $this->swapExtension($filename, $variant, 1);
+    }
+
+    public function restoreOriginalExtension(string $filename, string $variant): string
+    {
+        return $this->swapExtension($filename, $variant, 0);
+    }
+
+    private function swapExtension(
+        string $filename,
+        string $variant,
+        int $extIndex
+    ): string
+    {
+        if (empty($variant)) {
+            return $filename;
+        }
+
+        $subVariants = explode('_', $variant);
+
+        if (!preg_match('/(.+)\.([a-z\d]+)$/i', $filename, $matches)) {
+            return $filename;
+        }
+
+        [$_, $filenameWitoutExtension, $extension] = $matches;
+
+        foreach ($subVariants as $subVariant) {
+            if (preg_match("/^extRewrite(.+)$/", $subVariant, $matches)) {
+                [$_, $base64] = $matches;
+                $extensionData = Convert::base64url_decode($base64);
+                $extension = $extensionData[$extIndex];
+            }
+        }
+
+        return $filenameWitoutExtension . '.' . $extension;
+
+    }
+}

--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -11,6 +11,11 @@ interface FileIDHelper
 {
 
     /**
+     * A special variant type that can be used to encode a variant filename with a different extension.
+     */
+    const EXTENSION_REWRITE_VARIANT = 'extRewrite';
+
+    /**
      * Map file tuple (hash, name, variant) to a filename to be used by flysystem
      *
      * @param string|ParsedFileID $filename Name of file or ParsedFileID object

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -19,6 +19,7 @@ use SilverStripe\Core\Injector\Injectable;
 class HashFileIDHelper implements FileIDHelper
 {
     use Injectable;
+    use AlternativeFileExtensionTrait;
 
     /**
      * Default length at which hashes are truncated.
@@ -41,6 +42,11 @@ class HashFileIDHelper implements FileIDHelper
         if ($cleanfilename) {
             $filename = $this->cleanFilename($filename);
         }
+
+        if ($variant) {
+            $filename = $this->rewriteVariantExtension($filename, $variant);
+        }
+
         $name = basename($filename);
 
         // Split extension
@@ -90,10 +96,15 @@ class HashFileIDHelper implements FileIDHelper
         }
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
+        $variant = isset($matches['variant']) ? $matches['variant'] : '';
+
+        if (isset($variant)) {
+            $filename = $this->restoreOriginalExtension($filename, $variant);
+        }
         return new ParsedFileID(
             $filename,
             $matches['hash'],
-            isset($matches['variant']) ? $matches['variant'] : '',
+            $variant,
             $fileID
         );
     }

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -17,6 +17,7 @@ use SilverStripe\Core\Injector\Injectable;
 class NaturalFileIDHelper implements FileIDHelper
 {
     use Injectable;
+    use AlternativeFileExtensionTrait;
 
     public function buildFileID($filename, $hash = null, $variant = null, $cleanfilename = true)
     {
@@ -30,6 +31,10 @@ class NaturalFileIDHelper implements FileIDHelper
         if ($cleanfilename) {
             $filename = $this->cleanFilename($filename);
         }
+        if ($variant) {
+            $filename = $this->rewriteVariantExtension($filename, $variant);
+        }
+
         $name = basename($filename);
 
         // Split extension
@@ -80,10 +85,16 @@ class NaturalFileIDHelper implements FileIDHelper
         }
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
+        $variant = isset($matches['variant']) ? $matches['variant'] : '';
+
+        if (isset($variant)) {
+            $filename = $this->restoreOriginalExtension($filename, $variant);
+        }
+
         return new ParsedFileID(
             $filename,
             '',
-            isset($matches['variant']) ? $matches['variant'] : '',
+            $variant,
             $fileID
         );
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -2,6 +2,9 @@
 
 namespace SilverStripe\Assets;
 
+use SilverStripe\Assets\Storage\AssetContainer;
+use SilverStripe\Assets\Storage\DBFile;
+
 /**
  * Represents an Image
  */
@@ -59,5 +62,16 @@ class Image extends File
         }
         $this->extend('updatePreviewLink', $link, $action);
         return $link;
+    }
+
+    public function ToImage(): ?AssetContainer
+    {
+        $image = parent::ToImage();
+
+        if (empty($image)) {
+            $image = $this->File;
+        }
+
+        return $image;
     }
 }

--- a/src/ImageBackendFactory.php
+++ b/src/ImageBackendFactory.php
@@ -51,7 +51,7 @@ class ImageBackendFactory implements Factory
 
         // Verify file exists before creating backend
         $backend = null;
-        if ($store->exists() && $store->getIsImage()) {
+        if ($store->exists()) {
             $backend = $this->creator->create($service, $params);
         }
 

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Assets;
 
 use InvalidArgumentException;
 use LogicException;
+use SilverStripe\Assets\FilenameParsing\FileIDHelper;
 use SilverStripe\Assets\Storage\AssetContainer;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\DBFile;
@@ -1001,7 +1002,7 @@ trait ImageManipulation
     public function manipulateExtension(string $newExtension, callable $callback)
     {
         $pathParts = pathinfo($this->getFilename());
-        $variant = $this->variantName('extRewrite', $pathParts['extension'], $newExtension);
+        $variant = $this->variantName(FileIDHelper::EXTENSION_REWRITE_VARIANT, $pathParts['extension'], $newExtension);
         return $this->manipulate($variant, $callback);
     }
 

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use LogicException;
 use Psr\Http\Message\StreamInterface;
 use Psr\SimpleCache\CacheInterface;
+use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Storage\AssetContainer;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Core\Config\Configurable;
@@ -364,7 +365,9 @@ class InterventionBackend implements Image_Backend, Flushable
             }
 
             // Save file
-            $extension = pathinfo($filename, PATHINFO_EXTENSION);
+            $url = $assetStore->getAsURL($filename, $hash, $variant, false);
+            $extension = pathinfo($url, PATHINFO_EXTENSION);
+
             $result = $assetStore->setFromString(
                 $resource->encode($extension, $this->getQuality())->getEncoded(),
                 $filename,

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -628,4 +628,12 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
             ->getStore()
             ->copy($this->Filename, $this->Hash, $newName);
     }
+
+    public function ToImage(): ?AssetContainer
+    {
+        $image = null;
+        $this->extend('ToImage', $image);
+
+        return $image;
+    }
 }

--- a/tests/php/FilenameParsing/AlternativeFileExtensionTest.php
+++ b/tests/php/FilenameParsing/AlternativeFileExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace SilverStripe\Assets\Tests\FilenameParsing;
+
+use SilverStripe\Assets\FilenameParsing\HashFileIDHelper;
+use SilverStripe\Assets\FilenameParsing\ParsedFileID;
+use SilverStripe\Core\Convert;
+use SilverStripe\Dev\SapphireTest;
+
+class AlternativeFileExtensionTest extends SapphireTest
+{
+
+
+    public function rewriteDataProvider()
+    {
+        $jpgToPng = 'extRewrite' . Convert::base64url_encode(['jpg', 'png']);
+
+        return [
+            'no variant' => ['', 'hello.txt', 'hello.txt'],
+            'invalid extension' => ['xyz', 'hello.abc+', 'hello.abc+'],
+            'no extension' => ['', 'hello.', 'hello.'],
+            'no filename' => ['', '.htaccess', '.htaccess'],
+            'no rewrite' => ['xyz', 'hello.jpg', 'hello.jpg'],
+            'no rewrite multi variant' => ['xyz_abc', 'hello.jpg', 'hello.jpg'],
+            'rewitten extension' => [$jpgToPng, 'hello.jpg', 'hello.png'],
+            'rewitten extension with other variants' => ["{$jpgToPng}_xyz", 'hello.jpg', 'hello.png'],
+        ];
+    }
+
+    /**
+     * @dataProvider rewriteDataProvider
+     */
+    public function testRewriteVariantExtension($variant, $inFilename, $outFilename)
+    {
+        $helper = new HashFileIDHelper();
+        $actualFilename = $helper->rewriteVariantExtension($inFilename, $variant);
+
+        $this->assertEquals($outFilename, $actualFilename);
+    }
+
+    /**
+     * @dataProvider rewriteDataProvider
+     */
+    public function testRestoreOriginalExtension($variant, $outFilename, $inFilename)
+    {
+        $helper = new HashFileIDHelper();
+        $actualFilename = $helper->restoreOriginalExtension($inFilename, $variant);
+
+        $this->assertEquals($outFilename, $actualFilename);
+    }
+}


### PR DESCRIPTION
This is just a proof-of-concept for now. Matching RFC https://github.com/silverstripe/silverstripe-assets/issues/441

# Background

Our asset system allows you to define "variants" of a file. Variants are are variation of the parent file. e.g.: A thumbnail of an image, or a cropped version of the original image.

This is quite a useful feature and allows any operation on the main file to be reflected on its variants. e.g: Deleting, publishing, unpublishing a file will do the same thing to all its variant. If you are granted access to a file, you automatically get access to its variants.

Currently variants are tracked by creating file with a variation on the name of the original file. e.g.: If you have an image called "Upload/logo.png", all it's variant will be called something like "Upload/logo__someVariantstring.png"

# Problem

Currently, variants must have the same extensions as the parent file. This foreclose a lot of interesting scenarios and in-effect means that variants are only useful for resizing/cropping images.

If we could have variants with extension that differ from their parents we could open this kind of possibilities:
* provide thumbnails for more file types (e.g.: We could take thumbnails for videos or documents)
* convert files to alternative formats (e.g.: .docx document could be converted to PDF on the fly or we could convert a PNG to JPG)

We probably wouldn't want to provide all these features out of the box in core, but we could provide a simple API that third parties could hook into to provide conversion features.

# Approach

This PR builds on some of our previous work with `FileIDHelper` concept. FileIDHelpers are responsible for:
* converting file tuple (an array with a file name, file hash, variant) to their equivalent File ID (path as a string),
* parsing File IDs back to their original file tuple,
* matching a file variant back to its original file.

This PR updates `FileIDHelper` classes so they can understand a special `extRewrite` variant. This variant as two parameters: the extension of the parent file and the extension that the new variant should have. 

When building the fileID from a tuple, the extension will swap to the new extension. When parsing a file ID back to its original tuple, the extension in the filename key is restored to the extension of the parent file.

For example, this tuple would be converted to this file ID:
`['Filename' => 'video.mp4', 'Hash' => 'b67fcb469a', 'variant' => 'extRewriteWyJtcDQiLCJqcGciXQ']` becomes `b67fcb469a/video__extRewriteWyJtcDQiLCJqcGciXQ.jpg`. `WyJtcDQiLCJqcGciXQ` is a base64 encoded representation of `['mp4','jpg']`.

# What would the API for this look like

This is based on the existing logic for creating thumbnails and the `manipulateImage` method. We might be able to provide a nicer API to do this.

```php
public function ToImage()
{
    return $file->manipulateExtension(
        'jpg',
        function (AssetStore $store, string $filename, string $hash, string $variant) use ($file) {
            $results = $file->getImageBackend();
            $results->setImageResource(VideoConverter::magicalMethod($file->getStream()));
            $tuple = $results->writeToStore($store, $filename, $hash, $variant, ['conflict' =>     AssetStore::CONFLICT_USE_EXISTING]);
            return [$tuple, $results];
        }
    );
}
```

# Extra complications

Most of the logic around generating thumbnails in assets and asset-admin has some safe guard to make sure you don't try generating thumbnails for regular files. Generating images for regular files is kind of the entire point of this, so we'll need to rewrite some of those safe guards or remove them altogether.

We might want to have dedicated API for this purpose as well. This will require some more thoughts.

On a UX consideration, the asset-admin GalleryItem currently only has thumbnails for images. If we move into a direction where PDF, Videos and other types of files can have thumbnails as well, we'll need to have a way to differentiate those files from regular images

# Related PR
* https://github.com/silverstripe/silverstripe-asset-admin/pull/1133