### PR TITLE
414: listContents no longer called recursively

### DIFF
--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -53,4 +53,11 @@ interface FileIDHelper
      * @return string
      */
     public function lookForVariantIn(ParsedFileID $parsedFileID);
+
+    /**
+     * Specify if this File ID Helper stores variants in subfolders and require a recursive look up to find all
+     * variants.
+     * @return bool
+     */
+    public function lookForVariantRecursive(): bool;
 }

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -436,7 +436,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 
             // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
-            $possibleVariants = $filesystem->listContents($folder, true);
+            $possibleVariants = $filesystem->listContents($folder, false);
 
             // Flysystem returns array of meta data abouch each file, we remove directories and map it down to the path
             $possibleVariants = array_filter($possibleVariants, function ($possibleVariant) {

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -436,7 +436,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 
             // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
-            $possibleVariants = $filesystem->listContents($folder, false);
+            $possibleVariants = $filesystem->listContents($folder, $helper->lookForVariantRecursive());
 
             // Flysystem returns array of meta data abouch each file, we remove directories and map it down to the path
             $possibleVariants = array_filter($possibleVariants, function ($possibleVariant) {

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -126,4 +126,9 @@ class HashFileIDHelper implements FileIDHelper
     {
         return substr($hash, 0, self::HASH_TRUNCATE_LENGTH);
     }
+
+    public function lookForVariantRecursive(): bool
+    {
+        return false;
+    }
 }

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -238,4 +238,9 @@ class LegacyFileIDHelper implements FileIDHelper
         }
         return $folder . '_resampled';
     }
+
+    public function lookForVariantRecursive(): bool
+    {
+        return true;
+    }
 }

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -99,4 +99,9 @@ class NaturalFileIDHelper implements FileIDHelper
         $folder = dirname($parsedFileID->getFilename());
         return $folder == '.' ? '' : $folder;
     }
+
+    public function lookForVariantRecursive(): bool
+    {
+        return false;
+    }
 }

--- a/tests/php/FilenameParsing/MockFileIDHelper.php
+++ b/tests/php/FilenameParsing/MockFileIDHelper.php
@@ -57,4 +57,9 @@ class MockFileIDHelper implements TestOnly, FileIDHelper
     {
         return $this->lookForVariantInVal;
     }
+
+    public function lookForVariantRecursive(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This assumes that variants for files are always in the same directory as the asset itself which will probably require some validation on what happens when you move a file around with its variations etc

Hopefully resolves: https://github.com/silverstripe/silverstripe-assets/issues/414