### PR TITLE
NEW Introduce PHP 8 and prefer-lowest builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1 COMPOSER_INSTALL_ARG="--prefer-lowest"
     - php: 7.2
       env: DB=PGSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
     - php: 7.3
@@ -30,25 +30,26 @@ matrix:
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PDO=1
     - php: 7.4
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+    - php: nightly
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 COMPOSER_INSTALL_ARG="--ignore-platform-reqs"
 
 before_script:
 # Init PHP
-  - printf "\n" | pecl install imagick
+  # TODO: Remove this condition once Imagick officially ships PHP 8 support
+  - if [ "$COMPOSER_ARG" != "--ignore-platform-reqs"]; then printf "\n" | pecl install imagick; fi
   - composer self-update || true
   - phpenv rehash
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || true
   - export PATH=~/.config/composer/vendor/bin:$PATH
   - echo 'memory_limit = 4G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 # Install composer dependencies
   - composer validate
-  - composer install --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:$RECIPE_VERSION silverstripe/versioned:1.x-dev
-  # Fix for running phpunit 5 on php 7.4+
-  - composer require --no-update sminnee/phpunit-mock-objects:^3
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2 --prefer-dist; fi
-  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - composer require --prefer-dist silverstripe/recipe-core:$RECIPE_VERSION silverstripe/versioned:1.x-dev $COMPOSER_INSTALL_ARG
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:^2 --prefer-dist $COMPOSER_INSTALL_ARG; fi
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o $COMPOSER_INSTALL_ARG; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then pecl install pcov ; composer require pcov/clobber --dev ; vendor/bin/pcov clobber; fi
+  - composer update --prefer-dist $COMPOSER_INSTALL_ARG
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1 COMPOSER_INSTALL_ARG="--prefer-lowest"
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 COMPOSER_INSTALL_ARG="--prefer-lowest"
     - php: 7.2
       env: DB=PGSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
     - php: 7.3
@@ -29,7 +29,7 @@ matrix:
     - php: 7.4
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PDO=1
     - php: 7.4
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: nightly
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1 COMPOSER_INSTALL_ARG="--ignore-platform-reqs"
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "silverstripe/versioned": "^1@dev",
         "sminnee/phpunit-mock-objects": "^3.4.5",
-        "phpunit/phpunit": "^5.7"
+        "sminnee/phpunit": "^5.7.29"
     },
     "suggest": {
         "ext-exif": "If you use GD backend (the default) you may want to have EXIF extension installed to elude some tricky issues"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "silverstripe/framework": "^4.5",
         "silverstripe/vendor-plugin": "^1.0",
-        "intervention/image": "^2.3"
+        "intervention/image": "^2.3",
+        "league/flysystem": "^1.0.70"
     },
     "require-dev": {
         "silverstripe/versioned": "^1@dev",


### PR DESCRIPTION
Notes:

- Imagick has PHP 8 support on their development branch, but this hasn't shipped yet, so I've disabled it for now. I can confirm the relevant tests pass in my local environment running the development build of Imagick.
- ~The build is failing due to its use of Prophecy, so it's in a [similar conundrum to silverstripe/config](https://github.com/silverstripe/silverstripe-config/pull/46#issuecomment-698574874). I'm now leaning towards @sminnee's suggestion of refactoring away from Prophecy.~ I've successfully refactored the affected tests into native PHPUnit mocks.
- The prefer-lowest build was broken by a since-fixed issue in Flysystem. I've added Flysystem as a direct dependency and bumped the minimum version in the process.