### PR TITLE
429: Ensure remove folder removes all exepcted files/folders/links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "silverstripe/versioned": "^1@dev",
         "sminnee/phpunit-mock-objects": "^3.4.5",
         "sminnee/phpunit": "^5.7.29",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3",
+        "mikey179/vfsstream": "^1.6"
     },
     "suggest": {
         "ext-exif": "If you use GD backend (the default) you may want to have EXIF extension installed to elude some tricky issues"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "silverstripe/framework": "^4.5",
         "silverstripe/vendor-plugin": "^1.0",
+        "symfony/filesystem": "^3.4|^4.0|^5.0",
         "intervention/image": "^2.3",
         "league/flysystem": "^1.0.70"
     },

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Assets;
 
+use FilesystemIterator;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\Deprecation;
@@ -61,15 +62,22 @@ class Filesystem
     public static function removeFolder($folder, $contentsOnly = false)
     {
         $fs = new SymfonyFilesystem();
-        $fs->remove($folder);
 
         if (!$contentsOnly) {
+            $fs->remove($folder);
+
             return;
         }
 
-        // The Symfony Filesystem doesn't have a method of only removing the contents of a folder,
-        // therefore we need to recreate the folder at the end
-        $fs->mkdir($folder, static::config()->folder_create_mask);
+        // If we've been asked to only delete the files then we will iterate through them and remove them
+        $files = new FilesystemIterator(
+            $folder,
+            FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::SKIP_DOTS
+        );
+
+        foreach ($files as $file) {
+            $fs->remove($file);
+        }
     }
 
     /**

--- a/tests/php/FilesystemTest.php
+++ b/tests/php/FilesystemTest.php
@@ -2,73 +2,125 @@
 
 namespace SilverStripe\Assets\Tests;
 
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Dev\SapphireTest;
 
 class FilesystemTest extends SapphireTest
 {
-    public function testRemoveFolderNormalCase()
+
+    /**
+     * Config directory name.
+     *
+     * @var string
+     */
+    protected $directory = 'config';
+
+    /**
+     * Root directory for virtual filesystem
+     *
+     * @var vfsStreamDirectory
+     */
+    protected $root;
+
+    protected function setUp()
     {
-        // Create a temporary folder
-        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
-        Filesystem::removeFolder($path);
-        mkdir($path);
-        // Chuck a "normal" folder inside it
-        $normalFolderPath = $path . DIRECTORY_SEPARATOR . 'normal';
-        mkdir($normalFolderPath);
-        // Ensure the folder inside exists
-        $this->assertTrue(is_dir($normalFolderPath));
-        // Remove the folder and ensure it's no longer there
-        Filesystem::removeFolder($normalFolderPath);
-        $this->assertFalse(is_dir($normalFolderPath));
-        // Add that folder back in
-        mkdir($normalFolderPath);
-        // And put a file inside
-        $filePath = $normalFolderPath . DIRECTORY_SEPARATOR . 'example-file';
-        file_put_contents($filePath, 'example');
-        // Ensure our path is still there and the file exists
-        $this->assertTrue(is_dir($path));
-        $this->assertTrue(is_file($filePath));
-        // Remove the path
-        Filesystem::removeFolder($path);
-        // Ensure it was removed
-        $this->assertFalse(is_dir($path));
-        // Ensure the "normal" folder was removed as part of the recursive removal
-        $this->assertFalse(is_dir($normalFolderPath));
-        // Ensure our file was deleted too
-        $this->assertFalse(is_file($filePath));
+        parent::setUp();
+        $this->root = vfsStream::setup(
+            'root',
+            null,
+            [
+                'rootfile.txt' => 'hello world',
+                'empty-folder' => [],
+                'not-empty-folder' => [
+                  'file.txt' => 'I\'m a file'
+                ],
+                'folder-with-subfolders' => [
+                    'empty-subfolder' => [],
+                    'not-empty-subfolder' => [
+                        'file-in-sub-folder.txt' => 'I am in a subfolder'
+                    ],
+                ],
+                'folder-with-falsy-file' => [
+                    '0' => 'If you parse my filename as an int, I will be false'
+                ]
+            ]
+        );
     }
 
-    public function testRemoveFolderFalsieNames()
+    private function buildPath(): string
     {
-        // Create a temporary folder
-        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
-        mkdir($path);
-        // Create a file with the name `0` which evaluates to false
-        $filePath = $path . DIRECTORY_SEPARATOR . '0';
-        file_put_contents($filePath, 'example');
-        // Try to remove the folder and file recursively
-        Filesystem::removeFolder($path);
-        // Ensure they were both removed
-        $this->assertFalse(is_dir($path));
-        $this->assertFalse(is_file($filePath));
+        $nodes = func_get_args();
+        array_unshift($nodes, $this->root->url());
+        return implode(DIRECTORY_SEPARATOR, $nodes);
+    }
+
+    public function testRemoveEmptyFolder()
+    {
+        $folderPath = $this->buildPath('empty-folder');
+        $this->assertDirectoryExists($folderPath);
+
+        Filesystem::removeFolder($folderPath);
+        $this->assertDirectoryNotExists($folderPath);
+    }
+
+    public function testRemoveFolderWithFiles()
+    {
+        $folderPath = $this->buildPath('not-empty-folder');
+        $filePath = $this->buildPath('not-empty-folder', 'file.txt');
+        $this->assertDirectoryExists($folderPath);
+        $this->assertFileExists($filePath);
+
+        Filesystem::removeFolder($folderPath);
+        $this->assertDirectoryNotExists($folderPath);
+        $this->assertFileNotExists($filePath);
+    }
+
+    public function testRemoveFolderWithSubFolder()
+    {
+        $folderPath = $this->buildPath('folder-with-subfolders');
+        $emptySubfolder = $this->buildPath('folder-with-subfolders', 'empty-subfolder');
+        $filePath = $this->buildPath('folder-with-subfolders', 'not-empty-subfolder', 'file-in-sub-folder.txt');
+
+        $this->assertDirectoryExists($folderPath);
+        $this->assertDirectoryExists($emptySubfolder);
+        $this->assertFileExists($filePath);
+
+        Filesystem::removeFolder($folderPath);
+        $this->assertDirectoryNotExists($folderPath);
+        $this->assertDirectoryNotExists($emptySubfolder);
+        $this->assertFileNotExists($filePath);
+    }
+
+    public function testRemoveFolderWithFalsyFile()
+    {
+        $folderPath = $this->buildPath('folder-with-falsy-file');
+        $filePath = $this->buildPath('folder-with-falsy-file', '0');
+        $this->assertDirectoryExists($folderPath);
+        $this->assertFileExists($filePath);
+
+        Filesystem::removeFolder($folderPath);
+        $this->assertDirectoryNotExists($folderPath);
+        $this->assertFileNotExists($filePath);
     }
 
     public function testRemovedFolderContentsOnly()
     {
-        // Create a temporary folder
-        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
-        mkdir($path);
-        // Create a file with the name `0` which evaluates to false
-        $filePath = $path . DIRECTORY_SEPARATOR . '0';
-        file_put_contents($filePath, 'example');
-        // Try to remove the folder and file recursively
-        Filesystem::removeFolder($path, true);
-        // Ensure the folder still exists
-        $this->assertTrue(is_dir($path));
-        // Ensure the asset doesn't exist
-        $this->assertFalse(is_file($filePath));
-        // Finally clean up after ourselves
-        Filesystem::removeFolder($path);
+        $folderPath = $this->buildPath('folder-with-subfolders');
+        $emptySubfolder = $this->buildPath('folder-with-subfolders', 'empty-subfolder');
+        $notEmptySubfolder = $this->buildPath('folder-with-subfolders', 'not-empty-subfolder');
+        $filePath = $this->buildPath('folder-with-subfolders', 'not-empty-subfolder', 'file-in-sub-folder.txt');
+
+        $this->assertDirectoryExists($folderPath);
+        $this->assertDirectoryExists($emptySubfolder);
+        $this->assertDirectoryExists($notEmptySubfolder);
+        $this->assertFileExists($filePath);
+
+        Filesystem::removeFolder($folderPath, true);
+        $this->assertDirectoryExists($folderPath);
+        $this->assertDirectoryNotExists($emptySubfolder);
+        $this->assertDirectoryNotExists($notEmptySubfolder);
+        $this->assertFileNotExists($filePath);
     }
 }

--- a/tests/php/FilesystemTest.php
+++ b/tests/php/FilesystemTest.php
@@ -11,6 +11,7 @@ class FilesystemTest extends SapphireTest
     {
         // Create a temporary folder
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
+        Filesystem::removeFolder($path);
         mkdir($path);
         // Chuck a "normal" folder inside it
         $normalFolderPath = $path . DIRECTORY_SEPARATOR . 'normal';

--- a/tests/php/FilesystemTest.php
+++ b/tests/php/FilesystemTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SilverStripe\Assets\Tests;
+
+use SilverStripe\Assets\Filesystem;
+use SilverStripe\Dev\SapphireTest;
+
+class FilesystemTest extends SapphireTest
+{
+    public function testRemoveFolderNormalCase()
+    {
+        // Create a temporary folder
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
+        mkdir($path);
+        // Chuck a "normal" folder inside it
+        $normalFolderPath = $path . DIRECTORY_SEPARATOR . 'normal';
+        mkdir($normalFolderPath);
+        // Ensure the folder inside exists
+        $this->assertTrue(is_dir($normalFolderPath));
+        // Remove the folder and ensure it's no longer there
+        Filesystem::removeFolder($normalFolderPath);
+        $this->assertFalse(is_dir($normalFolderPath));
+        // Add that folder back in
+        mkdir($normalFolderPath);
+        // And put a file inside
+        $filePath = $normalFolderPath . DIRECTORY_SEPARATOR . 'example-file';
+        file_put_contents($filePath, 'example');
+        // Ensure our path is still there and the file exists
+        $this->assertTrue(is_dir($path));
+        $this->assertTrue(is_file($filePath));
+        // Remove the path
+        Filesystem::removeFolder($path);
+        // Ensure it was removed
+        $this->assertFalse(is_dir($path));
+        // Ensure the "normal" folder was removed as part of the recursive removal
+        $this->assertFalse(is_dir($normalFolderPath));
+        // Ensure our file was deleted too
+        $this->assertFalse(is_file($filePath));
+    }
+
+    public function testRemoveFolderFalsieNames()
+    {
+        // Create a temporary folder
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
+        mkdir($path);
+        // Create a file with the name `0` which evaluates to false
+        $filePath = $path . DIRECTORY_SEPARATOR . '0';
+        file_put_contents($filePath, 'example');
+        // Try to remove the folder and file recursively
+        Filesystem::removeFolder($path);
+        // Ensure they were both removed
+        $this->assertFalse(is_dir($path));
+        $this->assertFalse(is_file($filePath));
+    }
+
+    public function testRemovedFolderContentsOnly()
+    {
+        // Create a temporary folder
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-assets';
+        mkdir($path);
+        // Create a file with the name `0` which evaluates to false
+        $filePath = $path . DIRECTORY_SEPARATOR . '0';
+        file_put_contents($filePath, 'example');
+        // Try to remove the folder and file recursively
+        Filesystem::removeFolder($path, true);
+        // Ensure the folder still exists
+        $this->assertTrue(is_dir($path));
+        // Ensure the asset doesn't exist
+        $this->assertFalse(is_file($filePath));
+        // Finally clean up after ourselves
+        Filesystem::removeFolder($path);
+    }
+}


### PR DESCRIPTION
In some instances the where the directory could be `0` or `false` then the while loop would exit due to the function `readdir` returning the entry name on success or false on failure.

This new method will ensure that if passed a folder it recursively deletes the directory and throws an exception if the item is not readable to ensure we inform users that something wrong has occurred.

I've also added test cases for the scenarios to ensure they all work as expected, the second falsie case was failing with the previous code.

This should fix: #429 
