### PR TITLE
#426: Ensure cache key doesn't contain invalid characters

### DIFF
--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -178,7 +178,11 @@ class Sha1FileHashingService implements FileHashingService, Flushable
     private function buildCacheKey($fileID, $fs)
     {
         $fsID = $this->getFilesystemKey($fs);
-        return base64_encode(sprintf('%s://%s', $fsID, $fileID));
+        $cacheKey = base64_encode(sprintf('%s://%s', $fsID, $fileID));
+        // base64_encode can contain `/` , but that is not a valid character in cache keys
+        // @see CacheItem::validateKey. We therefore replace it with the url encoded equivalent
+        // from https://tools.ietf.org/html/rfc4648#page-8 which is `_`
+        return strtr($cacheKey, ['/' => '_']);
     }
 
     /**


### PR DESCRIPTION
The cache key when converted to base64 can contain `/` which is an invalid character for the symphony [CacheItem](https://github.com/symfony/cache/blob/a7a14c4832760bd1fbd31be2859ffedc9b6ff813/CacheItem.php#L166)

The fix is to just replace that one character with the letter `a`, not 100% sure if that's appropriate or we should use some method to decide on a specific character?

This should fix #426 
