### PR TITLE
290: Enable logging for intervention exceptions

### DIFF
--- a/tests/php/InterventionBackendTest.php
+++ b/tests/php/InterventionBackendTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\Assets\Tests;
+
+use Intervention\Image\Exception\NotReadableException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger;
+use ReflectionMethod;
+use SilverStripe\Assets\Image;
+use SilverStripe\Assets\InterventionBackend;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+
+class InterventionBackendTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'InterventionBackendTest.yml';
+
+    public function testExceptionsCanGetLogged()
+    {
+        $logger = new TestLogger();
+        Injector::inst()->registerService($logger, LoggerInterface::class . '.InterventionBackend');
+        /** @var Image $image */
+        $image = $this->objFromFixture(Image::class, 'imageWithTitle');
+        // We need to use an actual image otherwise we can't get the backend instance
+        $image->setFromLocalFile(__DIR__ . DIRECTORY_SEPARATOR . 'ImageTest' . DIRECTORY_SEPARATOR . 'test-image.png');
+        /** @var InterventionBackend $backend */
+        $backend = $image->getImageBackend();
+
+        // We're using reflection here because the method is private
+        $reflectedMethod = new ReflectionMethod(
+            InterventionBackend::class,
+            'logException'
+        );
+        $reflectedMethod->setAccessible(true);
+        // Send off our exception
+        $reflectedMethod->invokeArgs($backend, [new NotReadableException('File not readable')]);
+
+        // Check it was recorded
+        $this->assertTrue($logger->hasErrorRecords());
+        $this->assertTrue($logger->hasDebugThatContains('File not readable'));
+
+        // Clean up afterwards
+        $image->delete();
+    }
+}

--- a/tests/php/InterventionBackendTest.php
+++ b/tests/php/InterventionBackendTest.php
@@ -20,8 +20,10 @@ class InterventionBackendTest extends SapphireTest
 
     public function testExceptionsCanGetLogged()
     {
+        // Set up the test logger
         $logger = new TestLogger();
-        Injector::inst()->registerService($logger, LoggerInterface::class . '.InterventionBackend');
+        Injector::inst()->registerService($logger, LoggerInterface::class . '.quiet');
+
         /** @var Image $image */
         $image = $this->objFromFixture(Image::class, 'imageWithTitle');
         // We need to use an actual image otherwise we can't get the backend instance
@@ -40,7 +42,7 @@ class InterventionBackendTest extends SapphireTest
 
         // Check it was recorded
         $this->assertTrue($logger->hasErrorRecords());
-        $this->assertTrue($logger->hasDebugThatContains('File not readable'));
+        $this->assertTrue($logger->hasErrorThatContains('File not readable'));
 
         // Clean up afterwards
         $image->delete();

--- a/tests/php/InterventionBackendTest.yml
+++ b/tests/php/InterventionBackendTest.yml
@@ -1,0 +1,10 @@
+SilverStripe\Assets\Folder:
+  folder1:
+    Name: folder
+SilverStripe\Assets\Image:
+  imageWithTitle:
+    Title: This is a image Title
+    FileFilename: folder/test-image.png
+    FileHash: 444065542b5dd5187166d8e1cd684e0d724c5a97
+    Parent: =>SilverStripe\Assets\Folder.folder1
+    Name: test-image.png


### PR DESCRIPTION
This adds in some logging for the InterventionBackend to help aid when looking at issues with assets
This comes from the enhancement: https://github.com/silverstripe/silverstripe-assets/issues/290

If this gets approved, I can then look to getting a PR added to the docs to document that this exists