### PR TITLE
Cast image dimensions from shortcode as int

### DIFF
--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -73,8 +73,8 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
         // Check if a resize is required
         $src = $record->getURL($allowSessionGrant);
         if ($record instanceof Image) {
-            $width = isset($args['width']) ? $args['width'] : null;
-            $height = isset($args['height']) ? $args['height'] : null;
+            $width = isset($args['width']) ? (int) $args['width'] : null;
+            $height = isset($args['height']) ? (int) $args['height'] : null;
             $hasCustomDimensions = ($width && $height);
             if ($hasCustomDimensions && (($width != $record->getWidth()) || ($height != $record->getHeight()))) {
                 $resized = $record->ResizedImage($width, $height);

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -89,6 +89,24 @@ class ImageShortcodeProviderTest extends SapphireTest
             ))
         );
     }
+    
+    public function testShortcodeHandlerDoesNotResampleToNonIntegerImagesSizes()
+    {
+        $image = $this->objFromFixture(Image::class, 'imageWithoutTitle');
+        $parser = new ShortcodeParser();
+        $parser->register('image', [ImageShortcodeProvider::class, 'handle_shortcode']);
+
+        $this->assertEquals(
+            sprintf(
+                '<img src="%s" alt="" width="50%" height="auto">',
+                $image->Link()
+            ),
+            $parser->parse(sprintf(
+                '[image id="%d" alt="" width="50%" height="auto"]',
+                $image->ID
+            ))
+        );
+    }
 
     public function testShortcodeHandlerFailsGracefully()
     {

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -98,11 +98,11 @@ class ImageShortcodeProviderTest extends SapphireTest
 
         $this->assertEquals(
             sprintf(
-                '<img src="%s" alt="" width="50%" height="auto">',
+                '<img src="%s" alt="" width="50%%" height="auto">',
                 $image->Link()
             ),
             $parser->parse(sprintf(
-                '[image id="%d" alt="" width="50%" height="auto"]',
+                '[image id="%d" alt="" width="50%%" height="auto"]',
                 $image->ID
             ))
         );


### PR DESCRIPTION
This prevents sizes like '50%' from triggering exceptions.
Fixes #434 (or at least prevents an exception)
Blocked by https://github.com/silverstripe/silverstripe-framework/pull/9872