### PR TITLE
Remove disabled extensions from allowed_extensions

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1446,12 +1446,17 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
                 $value = true;
             }
 
+            $key = strtolower($key);
             // Skip disabled extensions
             if (in_array($value, [null, false], true)) {
+                // Remove disabled extensions from pre-set list
+                if (in_array($key, $allowedExtensions)) {
+                    $allowedExtensions = array_diff($allowedExtensions, [$key]);
+                }
                 continue;
             }
 
-            $allowedExtensions[] = strtolower($key);
+            $allowedExtensions[] = $key;
         }
         return $allowedExtensions;
     }

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -801,7 +801,7 @@ class FileTest extends SapphireTest
     public function testGetAllowedExtensions($allowedExtensions, $expected)
     {
         Config::modify()->set(File::class, 'allowed_extensions', $allowedExtensions);
-        $this->assertSame($expected, $expected);
+        $this->assertSame(array_values($expected), array_values(File::getAllowedExtensions()));
     }
 
     /**


### PR DESCRIPTION
Fixes #438 

Currently the docs example doesn't work: https://docs.silverstripe.org/en/4/developer_guides/files/allowed_file_types/#file-extensions-validation

It just skips over the value and leaves the original in the list. This change removes it from the core list.