### PR TITLE
DOC Update PHPDoc for Upload_Validator::setAllowedMaxFileSize to reflect that a string can be provided

### DIFF
--- a/src/Upload_Validator.php
+++ b/src/Upload_Validator.php
@@ -152,7 +152,7 @@ class Upload_Validator
      * array('*' => 200, 'jpg' => 1000, '[doc]' => '5m')
      * </code>
      *
-     * @param array|int $rules
+     * @param array|int|string $rules
      */
     public function setAllowedMaxFileSize($rules)
     {


### PR DESCRIPTION
`Upload_Validator::setAllowedMaxFileSize()` accepts a size  provided as a string (e.g.: `'5MB'`). This change simply updates the PHPDoc to reflect this fact.