### PR TITLE
Make castDimension method public

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -1037,7 +1037,7 @@ trait ImageManipulation
      * @param string $dimension Name of dimension
      * @return int Validated value
      */
-    protected function castDimension($value, $dimension)
+    public function castDimension($value, $dimension)
     {
         // Check type
         if (!is_numeric($value)) {


### PR DESCRIPTION
...so its functionality can also be used by image manipulation extensions applied to the Image class.