### PR TITLE
BUG Properly handle empty image attributes

### DIFF
--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -145,7 +145,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
         // Rebuild shortcode
         $parts = [];
         foreach ($args as $name => $value) {
-            $htmlValue = Convert::raw2att($value ?: $name);
+            $htmlValue = Convert::raw2att($value);
             $parts[] = sprintf('%s="%s"', $name, $htmlValue);
         }
         return sprintf("[%s %s]", $shortcode, implode(' ', $parts));

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -73,6 +73,39 @@ class ImageShortcodeProviderTest extends SapphireTest
         );
     }
 
+    public function testShorcodeRegenrator()
+    {
+        $image = $this->objFromFixture(Image::class, 'imageWithTitle');
+        $parser = new ShortcodeParser();
+        $parser->register('image', [ImageShortcodeProvider::class, 'regenerate_shortcode']);
+
+        $this->assertEquals(
+            sprintf(
+                '[image id="%d" alt="My alt text" title="My Title &amp; special character" src="%s"]',
+                $image->ID,
+                $image->Link()
+            ),
+            $parser->parse(sprintf(
+                '[image id="%d" alt="My alt text" title="My Title & special character"]',
+                $image->ID
+            )),
+            'Shortcode regeneration properly reads attributes'
+        );
+
+        $this->assertEquals(
+            sprintf(
+                '[image id="%d" alt="" title="" src="%s"]',
+                $image->ID,
+                $image->Link()
+            ),
+            $parser->parse(sprintf(
+                '[image id="%d" alt="" title=""]',
+                $image->ID
+            )),
+            "Shortcode regeneration properly handles empty attributes"
+        );
+    }
+
     public function testShortcodeHandlerAddsDefaultAttributes()
     {
         $image = $this->objFromFixture(Image::class, 'imageWithoutTitle');


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/2489

The `regenerate_shortcode` handler is used to normalise the data sent to the WYSIWYG. Looks like it was set up to handle boolean attributes like `<input required />` by copying empty the name of the attributes to the value when the value is blank. The problem is that this would render out `[img title="title"]` for empty attributes.

Empty attributes would normally be stripped out anyway ... this is only a problem when the short code has been generated from outside the WYSIWYG.

Image tag don't normally have "boolean" attributes like `required`, so I don't think we need to worry about those. When I tried manually putting one in, it stop recognising the short code altogether ... so if you did put a boolean attribute in there, it wouldn't ever hit this bit of code anyway, 