### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## SilverStripe Assets Module
+## Silverstripe Assets Module
 
 [![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-assets.svg?branch=1)](https://travis-ci.com/silverstripe/silverstripe-assets)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150059510-385e2ca4-3fb9-41af-be58-feed85457d47.png)

See also silverstripe/silverstripe-framework#10206