### PR TITLE
NEW WebP support in CMS

### DIFF
--- a/_config/filetypes.yml
+++ b/_config/filetypes.yml
@@ -28,4 +28,4 @@ SilverStripe\Assets\File:
     css: 'CSS file'
     html: 'HTML file'
     htm: 'HTML file'
-    
+    webp: 'WEBP Image'

--- a/src/File.php
+++ b/src/File.php
@@ -207,7 +207,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         'docx', 'dotx', 'flv', 'gif', 'gpx', 'gz', 'hqx', 'ico', 'jpeg', 'jpg', 'kml',
         'm4a', 'm4v', 'mid', 'midi', 'mkv', 'mov', 'mp3', 'mp4', 'mpa', 'mpeg', 'mpg', 'ogg', 'ogv', 'pages',
         'pcx', 'pdf', 'png', 'pps', 'ppt', 'pptx', 'potx', 'ra', 'ram', 'rm', 'rtf', 'sit', 'sitx',
-        'tar', 'tgz', 'tif', 'tiff', 'txt', 'wav', 'webm', 'wma', 'wmv', 'xls', 'xlsx', 'xltx', 'zip',
+        'tar', 'tgz', 'tif', 'tiff', 'txt', 'wav', 'webm', 'webp', 'wma', 'wmv', 'xls', 'xlsx', 'xltx', 'zip',
         'zipx',
     ];
 
@@ -229,10 +229,10 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             'potm', 'potx', 'pps', 'ppt', 'pptx', 'rtf', 'txt', 'xhtml', 'xls', 'xlsx', 'xltm', 'xltx', 'xml',
         ],
         'image' => [
-            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff',
+            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff', 'webp'
         ],
         'image/supported' => [
-            'gif', 'jpeg', 'jpg', 'png', 'bmp', 'ico',
+            'gif', 'jpeg', 'jpg', 'png', 'bmp', 'ico', 'webp'
         ],
         'flash' => [
             'fla', 'swf'
@@ -257,6 +257,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         'gif' => Image::class,
         'bmp' => Image::class,
         'ico' => Image::class,
+        'webp' => Image::class,
     ];
 
     /**

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -64,6 +64,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         'image/x-icon',
         'image/vnd.microsoft.icon',
         'image/vnd.adobe.photoshop',
+        'image/webp',
     ];
 
     /**

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -194,33 +194,44 @@ class FileTest extends SapphireTest
         $this->assertNull($broken->Pad(100, 100));
     }
 
-    public function testAppCategory()
+    public function appCategoryDataProvider()
+    {
+        return [
+            ['image', 'jpg'],
+            ['image', 'JPG'],
+            ['image', 'JPEG'],
+            ['image', 'png'],
+            ['image', 'tif'],
+            ['image', 'webp'],
+            ['document', 'pdf'],
+            ['video', 'mov'],
+            ['audio', 'OGG'],
+        ];
+    }
+
+    /**
+     * @dataProvider appCategoryDataProvider
+     */
+    public function testAppCategory($category, $extension)
     {
         // Test various categories
-        $this->assertEquals('image', File::get_app_category('jpg'));
-        $this->assertEquals('image', File::get_app_category('JPG'));
-        $this->assertEquals('image', File::get_app_category('JPEG'));
-        $this->assertEquals('image', File::get_app_category('png'));
-        $this->assertEquals('image', File::get_app_category('tif'));
-        $this->assertEquals('document', File::get_app_category('pdf'));
-        $this->assertEquals('video', File::get_app_category('mov'));
-        $this->assertEquals('audio', File::get_app_category('OGG'));
+        $this->assertEquals($category, File::get_app_category($extension));
     }
 
     public function testGetCategoryExtensions()
     {
         // Test specific categories
         $images = [
-            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff'
+            'alpha', 'als', 'bmp', 'cel', 'gif', 'ico', 'icon', 'jpeg', 'jpg', 'pcx', 'png', 'ps', 'psd', 'tif', 'tiff', 'webp'
         ];
         $this->assertEquals($images, File::get_category_extensions('image'));
         $this->assertEquals(
-            ['bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png'],
+            ['bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'webp'],
             File::get_category_extensions('image/supported')
         );
         $this->assertEquals($images, File::get_category_extensions(['image', 'image/supported']));
         $this->assertEquals(
-            ['bmp', 'fla', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'swf'],
+            ['bmp', 'fla', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'swf', 'webp'],
             File::get_category_extensions(['flash', 'image/supported'])
         );
 


### PR DESCRIPTION
This PR adds support for WebP images. The CMS will essentially treat them like JPEG and PNG images.

Please note:
- I tested with GD ... didn't try Imagick
- This doesn't address the issue that some browsers (aka IE11) don't support WebP images. The CMS doesn't provide any feedback to content authors about the image potentially not working in older browsers.