### PR TITLE
BUG Don't auto grant session access when resampling images

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -303,10 +303,9 @@ trait ImageManipulation
 
         // Only update if resampled file is a smaller file size
         if ($resampled->getAbsoluteSize() < $this->getAbsoluteSize()) {
-            $url = $resampled->getURL();
+            $url = $resampled->getURL(false);
         }
     }
-
 
     /**
      * Generate a resized copy of this image with the given width & height.
@@ -705,7 +704,7 @@ trait ImageManipulation
     {
         $thumbnail = $this->Thumbnail($width, $height);
         if ($thumbnail) {
-            return $thumbnail->getURL();
+            return $thumbnail->getURL(false);
         }
         return $this->getIcon();
     }
@@ -1130,7 +1129,7 @@ trait ImageManipulation
                 'width' => $this->getWidth(),
                 'height' => $this->getHeight(),
                 'alt' => $this->getTitle(),
-                'src' => $this->getURL()
+                'src' => $this->getURL(false)
             ];
 
             if ($this->IsLazyLoaded()) {

--- a/tests/php/ImageManipulationTest.php
+++ b/tests/php/ImageManipulationTest.php
@@ -427,4 +427,28 @@ class ImageManipulationTest extends SapphireTest
             trim($image->renderWith(SSViewer::fromString($template)))
         );
     }
+
+    public function testThumbnailURL()
+    {
+        $img = $this->objFromFixture(Image::class, 'imageWithTitle');
+
+        // File needs to be in draft and users need to be anonymous to test the access
+        $this->logOut();
+        $img->doUnpublish();
+
+        $fileUrl = 'folder/444065542b/test-image__FillWzEwLDEwXQ.png';
+
+        $this->assertEquals(
+            '/assets/' . $fileUrl,
+            $img->ThumbnailURL(10, 10),
+            'Thumbnail URL is correct'
+        );
+
+        /** @var AssetStore assetStore */
+        $assetStore = Injector::inst()->get(AssetStore::class);
+        $this->assertFalse(
+            $assetStore->isGranted($fileUrl),
+            'Current user should not automatically be granted access to view thumbnail'
+        );
+    }
 }

--- a/tests/php/ImageTest.php
+++ b/tests/php/ImageTest.php
@@ -231,6 +231,32 @@ abstract class ImageTest extends SapphireTest
         $this->assertNotEquals($imageHQ->getURL(), $imageHQR->getSourceURL(), 'Path to the original image file was returned by getURL()');
     }
 
+    /**
+     * Tests that a URL to a resampled image is provided when force_resample is
+     * set to true, if the resampled file is smaller than the original.
+     */
+    public function testUpdateURL()
+    {
+        // Test resampled file is served when force_resample = true
+        Config::modify()->set(Image::class, 'force_resample', true);
+
+        $imageHQ = $this->objFromFixture(Image::class, 'highQualityJPEG');
+
+        // File needs to be in draft and users need to be anonymous to test the access
+        $this->logOut();
+        $imageHQ->doUnpublish();
+
+        $url = '';
+        $imageHQ->updateURL($url);
+
+        /** @var AssetStore assetStore */
+        $assetStore = Injector::inst()->get(AssetStore::class);
+        $this->assertFalse(
+            $assetStore->isGranted('folder/a870de278b/test-image-high-quality__Resampled.jpg'),
+            'Current user should not automatically be granted access to resampled image'
+        );
+    }
+
     public function testImageResize()
     {
         $image = $this->objFromFixture(Image::class, 'imageWithoutTitle');


### PR DESCRIPTION
We considered treating this as a security issue but decided that the amount of sensitive information in an image does not warrant it.

In some context, the CMS will grant your session permission to view a file irrespective of if you have access to view it. The specific thing we are trying to address here is being able to view a restricted image if it's added to a campaign.

Previous places where we addressed this included an option to [allow automatic  session grant](https://github.com/silverstripe/silverstripe-assets/blob/1/src/Shortcodes/FileShortcodeProvider.php#L52) via a config. I don't think we need to do this anymore since tho AssetStore now automatically grant you access to view files.

