### PR TITLE
ENH Fix deprecation issues for PHP 8.1 compatibility

### DIFF
--- a/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SS4FileMigrationHelperTest.php
@@ -122,8 +122,12 @@ class SS4FileMigrationHelperTest extends SapphireTest
             ->canvas(400, 300, '#142237')
             ->text($targetedStage, 20, 170, function (AbstractFont $font) {
                 $font->color('#44C8F5');
+                $font->align('');
+                $font->valign('');
             })->text($filename, 20, 185, function (AbstractFont $font) {
                 $font->color('#ffffff');
+                $font->align('');
+                $font->valign('');
             })->rectangle(20, 200, 100, 202, function (AbstractShape $shape) {
                 $shape->background('#DA1052');
             });


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10250

Fixes following deprecation warnings during unit tests
```
Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vendor/intervention/image/src/Intervention/Image/Gd/Font.php on line 232

Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vendor/intervention/image/src/Intervention/Image/Gd/Font.php on line 243
```