### PR TITLE
DEP Bump minimum version of intervention/image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/vendor-plugin": "^1.0",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
-        "intervention/image": "^2.6",
+        "intervention/image": "^2.7",
         "league/flysystem": "^1.0.70"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10278

Travis error https://app.travis-ci.com/github/silverstripe/silverstripe-installer/jobs/567049878#L1343 which is a --prefer-lowest job

Going from intervention/image [2.6.0 to 2.7.0](https://github.com/Intervention/image/compare/2.6.0...2.7.0#diff-064f7d680167b4d877af42ab5553df5f73751a42e745f96819aed14d3ff53372L19) - removes the references to `\GuzzleHttp\Psr7\stream_for()`

