### PR TITLE
MNT Rename test class to conform with standard naming convention

### DIFF
--- a/tests/php/FilenameParsing/FileIDHelperTest.php
+++ b/tests/php/FilenameParsing/FileIDHelperTest.php
@@ -9,7 +9,7 @@ use SilverStripe\Dev\SapphireTest;
  * All the `FileIDHelper` have the exact same signature and very similar structure. Their basic tests will share the
  * same structure.
  */
-abstract class FileIDHelperTester extends SapphireTest
+abstract class FileIDHelperTest extends SapphireTest
 {
 
     /**

--- a/tests/php/FilenameParsing/HashFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/HashFileIDHelperTest.php
@@ -5,7 +5,7 @@ use InvalidArgumentException;
 use SilverStripe\Assets\FilenameParsing\HashFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 
-class HashFileIDHelperTest extends FileIDHelperTester
+class HashFileIDHelperTest extends FileIDHelperTest
 {
 
     protected function getHelper()

--- a/tests/php/FilenameParsing/LegacyFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/LegacyFileIDHelperTest.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Assets\Tests\FilenameParsing;
 use SilverStripe\Assets\FilenameParsing\LegacyFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 
-class LegacyFileIDHelperTest extends FileIDHelperTester
+class LegacyFileIDHelperTest extends FileIDHelperTest
 {
 
     protected function getHelper()

--- a/tests/php/FilenameParsing/MigrationLegacyFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/MigrationLegacyFileIDHelperTest.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Assets\Tests\FilenameParsing;
 use SilverStripe\Assets\FilenameParsing\LegacyFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 
-class MigrationLegacyFileIDHelperTest extends FileIDHelperTester
+class MigrationLegacyFileIDHelperTest extends FileIDHelperTest
 {
 
     protected function getHelper()

--- a/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Assets\Tests\FilenameParsing;
 use SilverStripe\Assets\FilenameParsing\NaturalFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 
-class NaturalFileIDHelperTest extends FileIDHelperTester
+class NaturalFileIDHelperTest extends FileIDHelperTest
 {
 
     protected function getHelper()


### PR DESCRIPTION
This is currently a hardcoded exception to removing tests in our travis config because the file name isn't following the convention.
Moving to github actions, we don't want to have such hardcoded exceptions.

## Parent issue
- https://github.com/silverstripe/github-actions-ci-cd/issues/36