### PR TITLE
API File is not CMSPreviewable

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -20,7 +20,6 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLReadonlyField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
@@ -98,7 +97,7 @@ use SilverStripe\View\HTML;
  * @mixin RecursivePublishable
  * @mixin InheritedPermissionsExtension
  */
-class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewable, PermissionProvider, Resettable
+class File extends DataObject implements AssetContainer, Thumbnail, PermissionProvider, Resettable
 {
     use ImageManipulation;
 
@@ -116,7 +115,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     private static $singular_name = "File";
 
     private static $plural_name = "Files";
-    
+
     /**
      * Control whether images in the admin will be resampled
      *
@@ -571,13 +570,11 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     public function getCMSFields()
     {
         $image = HTML::createTag('img', [
-            'src' => $this->PreviewLink(),
             'alt' => $this->getTitle(),
             'class' => 'd-block mx-auto',
         ]);
 
         $fields = FieldList::create(
-            HTMLReadonlyField::create('IconFull', _t(__CLASS__.'.PREVIEW', 'Preview'), $image),
             TextField::create("Title", $this->fieldLabel('Title')),
             TextField::create("Name", $this->fieldLabel('Filename')),
             TextField::create("Filename", _t(__CLASS__.'.PATH', 'Path'))
@@ -1193,7 +1190,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         if (!$this->File->exists()) {
             return null;
         }
-            return $this->File->getMetaData();
+        return $this->File->getMetaData();
     }
 
     public function getMimeType()
@@ -1201,7 +1198,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         if (!$this->File->exists()) {
             return null;
         }
-            return $this->File->getMimeType();
+        return $this->File->getMimeType();
     }
 
     public function getStream()
@@ -1387,25 +1384,6 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     public function canViewFile()
     {
         return $this->File->canViewFile();
-    }
-
-    public function CMSEditLink()
-    {
-        $link = null;
-        $this->extend('updateCMSEditLink', $link);
-        return $link;
-    }
-
-    public function PreviewLink($action = null)
-    {
-        // Since AbsoluteURL can whitelist protected assets,
-        // do permission check first
-        if (!$this->canView()) {
-            return null;
-        }
-        $link = $this->getIcon();
-        $this->extend('updatePreviewLink', $link, $action);
-        return $link;
     }
 
     /**


### PR DESCRIPTION
The assets CMS section no longer uses the traditional preview panel. This class being previewable via the preview panel is no longer useful.

~~Now that the `CMSPreviewable` interface has been moved to the `silverstripe/admin` module (see https://github.com/silverstripe/silverstripe-admin/pull/1340 and https://github.com/silverstripe/silverstripe-framework/pull/10440), which is not a dependency of this module, it's time to stop implementing that interface here.~~
The `CMSPreviewable` interface isn't moving anymore (see No longer needed - see https://github.com/silverstripe/silverstripe-framework/pull/10440#issuecomment-1246137962) but I still think this PR is worthwhile.

Note that I have kept the `getMimeType()` method because that's useful for `File` generally.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1339