### PR TITLE
Rescue Master Branch PR: ENH Stop using old deprecated `allVersions` call

### DIFF
--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -143,7 +143,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
             $versionFilters['"WasPublished"'] = true;
         }
 
-        $oldVersionCount = $file->allVersions($versionFilters, "", 1)->count();
+        $oldVersionCount = $file->Versions($versionFilters, "", 1)->count();
         // Our hash was published at some other stage
         if ($oldVersionCount > 0) {
             return new ParsedFileID($file->getFilename(), $file->getHash(), $parsedFileID->getVariant());


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-assets/commit/f4259a148fa3f6139f85853d7af6d5f06e766e23

Targetting 1 because `allVersions()` is already deprecated and we don't want to be throwing deprecation warnings for core usage.

I only kept the actual change of method used - the other changes from the original commit caused failures in tests.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350