### PR TITLE
FIX: Ensure attributes are stored against the Image record (fixes #513)

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -1072,23 +1072,15 @@ trait ImageManipulation
      */
     private function copyImageBackend(): AssetContainer
     {
-        // Store result in new DBFile instance
-        /** @var DBFile $file */
-        $file = DBField::create_field(
-            'DBFile',
-            [
-                'Filename' => $this->getFilename(),
-                'Hash' => $this->getHash(),
-                'Variant' => $this->getVariant()
-            ]
-        );
+        $file = clone $this;
 
         $backend = $this->getImageBackend();
         if ($backend) {
             $file->setImageBackend($backend);
         }
 
-        return $file->setOriginal($this);
+        $file->File->setOriginal($this);
+        return $file;
     }
 
     /**
@@ -1106,6 +1098,9 @@ trait ImageManipulation
             $this->attributes,
             [$name => $value]
         ));
+
+        // If this file has already been rendered then AttributesHTML will be cached, so we have to clear the cache
+        $file->objCacheClear();
 
         return $file;
     }

--- a/tests/php/ImageManipulationTest.php
+++ b/tests/php/ImageManipulationTest.php
@@ -2,19 +2,16 @@
 
 namespace SilverStripe\Assets\Tests;
 
-use InvalidArgumentException;
 use Prophecy\Prophecy\ObjectProphecy;
 use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
-use SilverStripe\Assets\Image_Backend;
 use SilverStripe\Assets\InterventionBackend;
-use SilverStripe\Assets\Storage\AssetContainer;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\DBFile;
+use SilverStripe\Assets\Tests\ImageManipulationTest\LazyLoadAccessorExtension;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\View\SSViewer;
@@ -361,6 +358,29 @@ class ImageManipulationTest extends SapphireTest
             $image->LazyLoad(false)->LazyLoad($val)->IsLazyLoaded(),
             'Invalid value does not change Lazy Load Value'
         );
+    }
+
+    public function testLazyLoadIsAccessibleInExtensions()
+    {
+        Image::add_extension(LazyLoadAccessorExtension::class);
+
+        /** @var Image $origin */
+        $image = $this->objFromFixture(Image::class, 'imageWithTitle');
+
+        $this->assertTrue(
+            $image->LazyLoad(true)->getLazyLoadValueViaExtension(),
+            'Incorrect LazyLoad value reported by extension'
+        );
+        $this->assertFalse(
+            $image->LazyLoad(false)->getLazyLoadValueViaExtension(),
+            'Incorrect LazyLoad value reported by extension'
+        );
+        $this->assertTrue(
+            $image->LazyLoad(false)->LazyLoad(true)->getLazyLoadValueViaExtension(),
+            'Incorrect LazyLoad value reported by extension'
+        );
+
+        Image::remove_extension(LazyLoadAccessorExtension::class);
     }
 
     public function renderProvider()

--- a/tests/php/ImageManipulationTest/LazyLoadAccessorExtension.php
+++ b/tests/php/ImageManipulationTest/LazyLoadAccessorExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\ImageManipulationTest;
+
+use SilverStripe\Core\Extension;
+
+class LazyLoadAccessorExtension extends Extension
+{
+    public function getLazyLoadValueViaExtension(): bool
+    {
+        return $this->getOwner()->IsLazyLoaded();
+    }
+}


### PR DESCRIPTION
Proposed solution to #513 - pushing to see if CI builds pass.

Currently calling `Image::setAttributes()` will return a `DBFile` instance instead of a modified copy of the original image, this changes that behaviour. Both `Image` and `DBFile` implement the `AssetContainer` interface so this isn’t a BC break