### PR TITLE
Updating league/flysystem minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "silverstripe/vendor-plugin": "^1.0",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "intervention/image": "^2.7",
-        "league/flysystem": "^1.0.70"
+        "league/flysystem": "^1.1.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^2",


### PR DESCRIPTION
Updating to minimum version of ^1.1.0 to align with the minimum requirements with fullscreeninteractive/silverstripe-azure-blob-storage. 

Latest version of 1 is 1.1.9