### PR TITLE
ENH Check canViewFile permissions before automatically grant access

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -891,8 +891,12 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      * @param bool $grant Ensures that the url for any protected assets is granted for the current user.
      * @return string
      */
-    public function getURL($grant = true)
+    public function getURL($grant = false)
     {
+        if (!$grant && $this->canView()) {
+            $grant = true;
+        }
+        
         if ($this->File->exists()) {
             return $this->File->getURL($grant);
         }
@@ -905,8 +909,12 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      * @param bool $grant Ensures that the url for any protected assets is granted for the current user.
      * @return string
      */
-    public function getSourceURL($grant = true)
+    public function getSourceURL($grant = false)
     {
+        if (!$grant && $this->canView()) {
+            $grant = true;
+        }
+
         if ($this->File->exists()) {
             return $this->File->getSourceURL($grant);
         }

--- a/tests/php/Shortcodes/ImageShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/ImageShortcodeProviderTest.php
@@ -256,6 +256,15 @@ class ImageShortcodeProviderTest extends SapphireTest
         $html = ImageShortcodeProvider::regenerate_shortcode($args, '', '', 'image');
         $this->assertSame($expected, $html);
         $this->assertFalse($assetStore->isGranted($parsedFileID));
+
+        // Login as member with 'VIEW_DRAFT_CONTENT' permisson to access to file and get session access
+        $this->logOut();
+
+        $this->logInWithPermission('VIEW_DRAFT_CONTENT');
+        // Provide permissions to view file for any logged in users
+        $image->CanViewType = InheritedPermissions::LOGGED_IN_USERS;
+        $image->write();
+
         Config::modify()->set(FileShortcodeProvider::class, 'allow_session_grant', true);
         $html = ImageShortcodeProvider::regenerate_shortcode($args, '', '', 'image');
         $this->assertSame($expected, $html);


### PR DESCRIPTION
### Description
Add condition to check if user has access to view the file and only then give him a session grant access to the file.

### Parent Issue
- https://github.com/silverstripe/silverstripe-assets/issues/501