### PR TITLE
MNT Fix variant for image manipulation test

### DIFF
--- a/tests/php/ImageManipulationTest.php
+++ b/tests/php/ImageManipulationTest.php
@@ -367,7 +367,7 @@ class ImageManipulationTest extends SapphireTest
     {
         $alt = 'This is a image Title';
         $src = '/assets/ImageTest/folder/test-image.png';
-        $srcCroped = '/assets/ImageTest/folder/test-image__CropWidthWyIxMDAiXQ.png';
+        $srcCroped = '/assets/ImageTest/folder/test-image__CropWidthWzEwMF0.png';
 
         return [
             'Simple output' => [


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/actions/runs/3139439033/jobs/5099856508
>
```
SilverStripe\Assets\Tests\ImageManipulationTest::testRender with data set "ImageManipulation" ('$Me.CropWidth(100)', '<img width="100" height="300"...zy" />')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<img width="100" height="300" alt="This is a image Title" src="/assets/ImageTest/folder/test-image__CropWidthWyIxMDAiXQ.png" loading="lazy" />'
+'<img width="100" height="300" alt="This is a image Title" src="/assets/ImageTest/folder/test-image__CropWidthWzEwMF0.png" loading="lazy" />'
```

The old base64 encoded string "WyIxMDAiXQ" evaluates to `["100"]`, and the new one ("WzEwMF0") evaluates to `[100]`. This is a result of [this PR](https://github.com/silverstripe/silverstripe-framework/pull/10497) in framework which allows primitive types to be passed directly to method arguments in templates. So where `100` had previously been interpreted as a string through the template logic, it's now a true int.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/594