### PR TITLE
DEP Upgrade legue/flysystem to version 3.0

### DIFF
--- a/_config/asset.yml
+++ b/_config/asset.yml
@@ -10,14 +10,14 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Assets\Flysystem\ProtectedAssetAdapter
   # Define the default filesystem
   League\Flysystem\Filesystem.public:
-    class: League\Flysystem\Filesystem
+    class: SilverStripe\Assets\Flysystem\Filesystem
     constructor:
       FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\PublicAdapter'
       FilesystemConfig:
         visibility: public
   # Define the secondary filesystem for protected assets
   League\Flysystem\Filesystem.protected:
-    class: League\Flysystem\Filesystem
+    class: SilverStripe\Assets\Flysystem\Filesystem
     constructor:
       FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\ProtectedAdapter'
       FilesystemConfig:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "silverstripe/vendor-plugin": "^2",
         "symfony/filesystem": "^6.1",
         "intervention/image": "^2.7.2",
-        "league/flysystem": "^1.1.9"
+        "league/flysystem": "^3.9.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^3",

--- a/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
+++ b/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
@@ -146,7 +146,7 @@ class LegacyThumbnailMigrationHelper
 
         $foundError = false;
         // Recurse through folder
-        foreach ($filesystem->listContents($resampledFolderPath, true) as $fileInfo) {
+        foreach ($filesystem->listContents($resampledFolderPath, true)->toArray() as $fileInfo) {
             if ($fileInfo['type'] !== 'file') {
                 continue;
             }
@@ -179,7 +179,7 @@ class LegacyThumbnailMigrationHelper
                 continue;
             }
 
-            $filesystem->rename($oldResampledPath, $newResampledPath);
+            $filesystem->move($oldResampledPath, $newResampledPath);
 
             $this->logger->info(sprintf('Moved legacy thumbnail %s to %s', $oldResampledPath, $newResampledPath));
 
@@ -190,13 +190,13 @@ class LegacyThumbnailMigrationHelper
         // get migrated leave the folder where it is.
         if (!$foundError) {
             $files = array_filter(
-                $filesystem->listContents($resampledFolderPath, true) ?? [],
+                $filesystem->listContents($resampledFolderPath, true)->toArray() ?? [],
                 function ($file) {
                     return $file['type'] === 'file';
                 }
             );
             if (empty($files)) {
-                $filesystem->deleteDir($resampledFolderPath);
+                $filesystem->deleteDirectory($resampledFolderPath);
             } else {
                 // This should not be possible. If it is, then there's probably a bug.
                 $this->logger->error(sprintf(

--- a/src/Dev/TestAssetStore.php
+++ b/src/Dev/TestAssetStore.php
@@ -2,11 +2,10 @@
 
 namespace SilverStripe\Assets\Dev;
 
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\AdapterInterface;
-use League\Flysystem\Filesystem;
+use League\Flysystem\Visibility;
 use SilverStripe\Assets\FilenameParsing\FileResolutionStrategy;
 use SilverStripe\Assets\Filesystem as SSFilesystem;
+use SilverStripe\Assets\Flysystem\LocalFilesystemAdapter;
 use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Flysystem\ProtectedAssetAdapter;
 use SilverStripe\Assets\Flysystem\PublicAssetAdapter;
@@ -16,6 +15,7 @@ use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\AssetStoreRouter;
 use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Assets\File;
+use SilverStripe\Assets\Flysystem\Filesystem;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 use SilverStripe\Control\Controller;
@@ -65,14 +65,14 @@ class TestAssetStore extends FlysystemAssetStore implements TestOnly
         $publicFilesystem = new Filesystem(
             $publicAdapter,
             [
-                'visibility' => AdapterInterface::VISIBILITY_PUBLIC
+                'visibility' => Visibility::PUBLIC
             ]
         );
         $protectedAdapter = new ProtectedAssetAdapter(ASSETS_PATH . '/' . $basedir . '/.protected');
         $protectedFilesystem = new Filesystem(
             $protectedAdapter,
             [
-                'visibility' => AdapterInterface::VISIBILITY_PRIVATE
+                'visibility' => Visibility::PRIVATE
             ]
         );
 
@@ -156,9 +156,9 @@ class TestAssetStore extends FlysystemAssetStore implements TestOnly
         if (!$forceProtected && !$filesystem->has($fileID)) {
             $filesystem = $assetStore->getPublicFilesystem();
         }
-        /** @var Local $adapter */
+        /** @var LocalFilesystemAdapter $adapter */
         $adapter = $filesystem->getAdapter();
-        return $relative ? $fileID : $adapter->applyPathPrefix($fileID);
+        return $relative ? $fileID : $adapter->prefixPath($fileID);
     }
 
     public function cleanFilename($filename)

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Assets\FilenameParsing;
 
 use InvalidArgumentException;
 use League\Flysystem\Filesystem;
+use League\Flysystem\UnableToCheckExistence;
 use SilverStripe\Assets\Storage\FileHashingService;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
@@ -298,7 +299,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
      * @param ParsedFileID $parsedFileID
      * @param Filesystem $filesystem
      * @return bool|string
-     * @throws \League\Flysystem\FileNotFoundException
+     * @throws UnableToCheckExistence
      */
     private function findHashOf(FileIDHelper $helper, ParsedFileID $parsedFileID, Filesystem $filesystem)
     {
@@ -436,7 +437,7 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 
             // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
-            $possibleVariants = $filesystem->listContents($folder, $helper->lookForVariantRecursive());
+            $possibleVariants = $filesystem->listContents($folder, $helper->lookForVariantRecursive())->toArray();
 
             // Flysystem returns array of meta data abouch each file, we remove directories and map it down to the path
             $possibleVariants = array_filter($possibleVariants ?? [], function ($possibleVariant) {

--- a/src/FilenameParsing/FileResolutionStrategy.php
+++ b/src/FilenameParsing/FileResolutionStrategy.php
@@ -68,7 +68,7 @@ interface FileResolutionStrategy
      * @param array|ParsedFileID $tuple
      * @param Filesystem $filesystem
      * @return generator|ParsedFileID[]|null
-     * @throws \League\Flysystem\FileNotFoundException
+     * @throws \League\Flysystem\UnableToCheckExistence
      */
     public function findVariants($tuple, Filesystem $filesystem);
 

--- a/src/Flysystem/Filesystem.php
+++ b/src/Flysystem/Filesystem.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Assets\Flysystem;
+
+use League\Flysystem\Filesystem as LeagueFilesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\PathNormalizer;
+use League\Flysystem\WhitespacePathNormalizer;
+
+class Filesystem extends LeagueFilesystem
+{
+    private $adapter;
+
+    public function __construct(
+        FilesystemAdapter $adapter,
+        array $config = [],
+        PathNormalizer $pathNormalizer = null
+    ) {
+        $this->adapter = $adapter;
+        $this->pathNormalizer = $pathNormalizer ?: new WhitespacePathNormalizer();
+        parent::__construct($adapter, $config, $pathNormalizer);
+    }
+
+    public function getAdapter(): FilesystemAdapter
+    {
+        return $this->adapter;
+    }
+
+    public function has(string $location): bool
+    {
+        $path = $this->pathNormalizer->normalizePath($location);
+
+        return strlen($path) === 0 ? false : ($this->getAdapter()->fileExists($path) || $this->getAdapter()->directoryExists($path));
+    }
+}

--- a/src/Flysystem/GeneratedAssets.php
+++ b/src/Flysystem/GeneratedAssets.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\Assets\Flysystem;
 
 use Exception;
-use League\Flysystem\File;
-use League\Flysystem\Filesystem;
+use SilverStripe\Assets\Flysystem\Filesystem;
+use League\Flysystem\UnableToWriteFile;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 
 /**
@@ -80,7 +80,7 @@ class GeneratedAssets implements GeneratedAssetHandler
      * @param string $filename
      * @param callable $callback
      * @return bool Whether or not the file exists
-     * @throws Exception If an error has occurred during save
+     * @throws UnableToWriteFile If an error has occurred during save
      */
     protected function checkOrCreate($filename, $callback = null)
     {
@@ -102,21 +102,17 @@ class GeneratedAssets implements GeneratedAssetHandler
     public function setContent($filename, $content)
     {
         // Store content
-        $result = $this
-                ->getFilesystem()
-                ->put($filename, $content);
-
-        if (!$result) {
-            throw new Exception("Error regenerating file \"{$filename}\"");
-        }
+        $this->getFilesystem()->write($filename, $content);
     }
 
     public function removeContent($filename)
     {
-        if ($this->getFilesystem()->has($filename)) {
-            /** @var File $handler */
-            $handler = $this->getFilesystem()->get($filename);
-            $handler->delete();
+        $filesystem = $this->getFilesystem();
+        
+        if ($filesystem->directoryExists($filename)) {
+            $filesystem->deleteDirectory($filename);
+        } elseif ($filesystem->fileExists($filename)) {
+            $filesystem->delete($filename);
         }
     }
 }

--- a/src/Flysystem/LocalFilesystemAdapter.php
+++ b/src/Flysystem/LocalFilesystemAdapter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\Assets\Flysystem;
+
+use League\Flysystem\Local\LocalFilesystemAdapter as LeagueLocalFilesystemAdapter;
+use League\Flysystem\PathPrefixer;
+use League\Flysystem\UnixVisibility\VisibilityConverter;
+use League\MimeTypeDetection\MimeTypeDetector;
+
+class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter
+{
+    private PathPrefixer $pathPrefixer;
+
+    public function __construct(
+        string $location,
+        VisibilityConverter $visibility = null,
+        int $writeFlags = LOCK_EX,
+        int $linkHandling = self::DISALLOW_LINKS,
+        MimeTypeDetector $mimeTypeDetector = null
+    ) {
+        $this->pathPrefixer = new PathPrefixer($location);
+        parent::__construct($location, $visibility, $writeFlags, $linkHandling, $mimeTypeDetector);
+    }
+
+    public function prefixPath(string $path): string
+    {
+        return $this->pathPrefixer->prefixPath($path);
+    }
+}

--- a/src/Flysystem/ProtectedAdapter.php
+++ b/src/Flysystem/ProtectedAdapter.php
@@ -2,12 +2,12 @@
 
 namespace SilverStripe\Assets\Flysystem;
 
-use League\Flysystem\AdapterInterface;
+use League\Flysystem\FilesystemAdapter;
 
 /**
  * An adapter which does not publicly expose protected files
  */
-interface ProtectedAdapter extends AdapterInterface
+interface ProtectedAdapter extends FilesystemAdapter
 {
 
     /**

--- a/src/Flysystem/PublicAdapter.php
+++ b/src/Flysystem/PublicAdapter.php
@@ -2,12 +2,12 @@
 
 namespace SilverStripe\Assets\Flysystem;
 
-use League\Flysystem\AdapterInterface;
+use League\Flysystem\FilesystemAdapter;
 
 /**
  * Represents an AbstractAdapter which exposes its assets via public urls
  */
-interface PublicAdapter extends AdapterInterface
+interface PublicAdapter extends FilesystemAdapter
 {
 
     /**

--- a/src/Storage/FileHashingService.php
+++ b/src/Storage/FileHashingService.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\Assets\Storage;
 
-use League\Flysystem\FileNotFoundException;
+use League\Flysystem\UnableToCheckExistence;
 use League\Flysystem\Filesystem;
 
 /**
@@ -27,7 +27,7 @@ interface FileHashingService
      * @param string $fileID
      * @param Filesystem|string $fs
      * @return string
-     * @throws FileNotFoundException
+     * @throws UnableToCheckExistence
      */
     public function computeFromFile($fileID, $fs);
 

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -4,8 +4,8 @@ namespace SilverStripe\Assets\Storage;
 
 use InvalidArgumentException;
 use League\Flysystem\Filesystem;
-use League\Flysystem\Util;
 use Psr\SimpleCache\CacheInterface;
+use SilverStripe\Assets\Util;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injectable;
@@ -195,7 +195,7 @@ class Sha1FileHashingService implements FileHashingService, Flushable
     {
         $filesystem = $this->getFilesystem($fs);
         return $filesystem->has($fileID) ?
-            $filesystem->getTimestamp($fileID) :
+            $filesystem->lastModified($fileID) :
             DBDatetime::now()->getTimestamp();
     }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\Assets;
+
+class Util
+{
+    public static function rewindStream($resource): void
+    {
+        self::checkIsResource($resource);
+        if (ftell($resource) !== 0 && static::isSeekableStream($resource)) {
+            rewind($resource);
+        }
+    }
+
+    public static function isSeekableStream($resource): bool
+    {
+        self::checkIsResource($resource);
+
+        return stream_get_meta_data($resource)['seekable'];
+    }
+
+    private static function checkIsResource($resource): void
+    {
+        if (!is_resource($resource)) {
+            throw new \InvalidArgumentException('$resource argument is not a valid resource');
+        }
+    }
+}

--- a/tests/php/Dev/Tasks/FileMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/FileMigrationHelperTest.php
@@ -75,25 +75,25 @@ class FileMigrationHelperTest extends SapphireTest
         foreach (Image::get() as $file) {
             $filename = $file->generateFilename();
             rewind($fromMain);
-            $fs->write($filename, $fromMain);
+            $fs->writeStream($filename, $fromMain);
 
             $dir = dirname($filename ?? '');
             $basename = basename($filename ?? '');
 
             rewind($fromVariant);
-            $fs->write($dir . '/_resampled/resizeXYZ/' . $basename, $fromVariant);
+            $fs->writeStream($dir . '/_resampled/resizeXYZ/' . $basename, $fromVariant);
             rewind($fromVariant);
-            $fs->write($dir . '/_resampled/resizeXYZ/scaleABC/' . $basename, $fromVariant);
+            $fs->writeStream($dir . '/_resampled/resizeXYZ/scaleABC/' . $basename, $fromVariant);
             rewind($fromVariant);
-            $fs->write($dir . '/_resampled/ScaleWidthWzEwMF0-' . $basename, $fromVariant);
+            $fs->writeStream($dir . '/_resampled/ScaleWidthWzEwMF0-' . $basename, $fromVariant);
             rewind($fromVariant);
-            $fs->write($dir . '/_resampled/ScaleWidthWzEwMF0-FitWzEwMCwxMDBd-' . $basename, $fromVariant);
+            $fs->writeStream($dir . '/_resampled/ScaleWidthWzEwMF0-FitWzEwMCwxMDBd-' . $basename, $fromVariant);
         }
         fclose($fromMain);
         fclose($fromVariant);
 
-        $fs->rename('wrong-case.txt', 'wRoNg-CaSe.tXt');
-        $fs->rename('Uploads/good-case-bad-folder.txt', 'uploads/good-case-bad-folder.txt');
+        $fs->move('wrong-case.txt', 'wRoNg-CaSe.tXt');
+        $fs->move('Uploads/good-case-bad-folder.txt', 'uploads/good-case-bad-folder.txt');
         $fs->copy('too-many-alternative-case.txt', 'Too-Many-Alternative-Case.txt');
         $fs->copy('too-many-alternative-case.txt', 'Too-Many-Alternative-Case.TXT');
         $fs->delete('too-many-alternative-case.txt');

--- a/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
+++ b/tests/php/Dev/Tasks/SecureAssetsMigrationHelperTest.php
@@ -112,7 +112,7 @@ TXT;
             ],
             'Unprotected' => [
                 'unprotected',
-                null,
+                '',
                 false
             ],
             'Protected with modified htaccess' => [

--- a/tests/php/Flysystem/AssetAdapterTest.php
+++ b/tests/php/Flysystem/AssetAdapterTest.php
@@ -58,8 +58,7 @@ class AssetAdapterTest extends SapphireTest
         $this->assertFileExists($this->rootDir . '/.htaccess');
         $this->assertFileDoesNotExist($this->rootDir . '/web.config');
 
-        $htaccess = $adapter->read('.htaccess');
-        $content = $htaccess['contents'];
+        $content = $adapter->read('.htaccess');
         // Allowed extensions set
         $this->assertStringContainsString('RewriteCond %{REQUEST_URI} !^[^.]*[^\/]*\.(?i:', $content);
         foreach (File::getAllowedExtensions() as $extension) {
@@ -74,7 +73,7 @@ class AssetAdapterTest extends SapphireTest
         file_put_contents($this->rootDir . '/.htaccess', '# broken content');
         $adapter->flush();
         $htaccess2 = $adapter->read('.htaccess');
-        $this->assertEquals($content, $htaccess2['contents']);
+        $this->assertEquals($content, $htaccess2);
 
         // Test URL
         $this->assertEquals('/assets/AssetAdapterTest/file.jpg', $adapter->getPublicUrl('file.jpg'));

--- a/tests/php/Flysystem/FlysystemAssetStoreTest.php
+++ b/tests/php/Flysystem/FlysystemAssetStoreTest.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\Assets\Tests\Flysystem;
 
-use League\Flysystem\Filesystem;
 use SilverStripe\Assets\FilenameParsing\FileIDHelperResolutionStrategy;
 use SilverStripe\Assets\FilenameParsing\FileResolutionStrategy;
+use SilverStripe\Assets\Flysystem\Filesystem;
 use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Flysystem\ProtectedAssetAdapter;
 use SilverStripe\Assets\Flysystem\PublicAssetAdapter;
@@ -49,7 +49,7 @@ class FlysystemAssetStoreTest extends SapphireTest
             ->getMock();
 
         $this->publicFilesystem = $this->getMockBuilder(Filesystem::class)
-            ->setMethods(['has', 'read', 'readStream', 'getTimestamp'])
+            ->setMethods(['has', 'read', 'readStream', 'lastModified'])
             ->setConstructorArgs([$this->publicAdapter])
             ->getMock();
 
@@ -58,7 +58,7 @@ class FlysystemAssetStoreTest extends SapphireTest
             ->getMock();
 
         $this->protectedFilesystem = $this->getMockBuilder(Filesystem::class)
-            ->setMethods(['has', 'read', 'readStream', 'getTimestamp'])
+            ->setMethods(['has', 'read', 'readStream', 'lastModified'])
             ->setConstructorArgs([$this->protectedAdapter])
             ->getMock();
 

--- a/tests/php/ProtectedFileControllerTest.php
+++ b/tests/php/ProtectedFileControllerTest.php
@@ -349,7 +349,7 @@ class ProtectedFileControllerTest extends FunctionalTest
             // 'text/plain' for test case pdfs in php7.4 + 8.0 , though in php8.1 it will
             // return 'application/octet-stream' which is then converted to 'application/pdf'
             // based on the file extension
-            $this->assertTrue(in_array($response->getHeader('Content-Type'), ['text/plain', 'application/pdf']));
+            $this->assertTrue(in_array($response->getHeader('Content-Type'), ['text/plain', 'application/pdf', 'application/octet-stream']));
         } else {
             $this->assertTrue($response->isError());
         }

--- a/tests/php/RedirectFileControllerTest.php
+++ b/tests/php/RedirectFileControllerTest.php
@@ -141,7 +141,7 @@ class RedirectFileControllerTest extends FunctionalTest
         // This replicates a scenario where a file was publish under a hash path in SilverStripe 4.3
         $store = $this->getAssetStore();
         $fs = $store->getPublicFilesystem();
-        $fs->rename($naturalUrl, $hashUrl);
+        $fs->move($naturalUrl, $hashUrl);
 
         $response = $this->get('assets/' . $naturalUrl);
         $this->assertResponse(

--- a/tests/php/Storage/AssetStoreTest.php
+++ b/tests/php/Storage/AssetStoreTest.php
@@ -419,7 +419,7 @@ class AssetStoreTest extends SapphireTest
         );
         $fishMeta = $backend->getMetadata($fishTuple['Filename'], $fishTuple['Hash']);
         $this->assertEquals(151889, $fishMeta['size']);
-        $this->assertEquals('file', $fishMeta['type']);
+        $this->assertEquals('image/jpeg', $fishMeta['type']);
         $this->assertNotEmpty($fishMeta['timestamp']);
 
         // text
@@ -431,7 +431,7 @@ class AssetStoreTest extends SapphireTest
         );
         $puppiesMeta = $backend->getMetadata($puppiesTuple['Filename'], $puppiesTuple['Hash']);
         $this->assertEquals(7, $puppiesMeta['size']);
-        $this->assertEquals('file', $puppiesMeta['type']);
+        $this->assertEquals('text/plain', $puppiesMeta['type']);
         $this->assertNotEmpty($puppiesMeta['timestamp']);
     }
 
@@ -891,7 +891,7 @@ class AssetStoreTest extends SapphireTest
             $variantParsedFileID->getVariant()
         );
 
-        $this->assertTrue($fs->has($expectedVariantPath));
+        $this->assertTrue($fs->fileExists($expectedVariantPath));
     }
 
     public function listOfFilesToNormalise()
@@ -990,12 +990,12 @@ class AssetStoreTest extends SapphireTest
         $fs = $this->getFilesystem($fsName);
 
         foreach ($expected as $expectedFile) {
-            $this->assertTrue($fs->has($expectedFile), "$expectedFile should exists");
+            $this->assertTrue($fs->fileExists($expectedFile), "$expectedFile should exists");
             $this->assertNotEmpty($fs->read($expectedFile), "$expectedFile should be non empty");
         }
 
         foreach ($notExpected as $notExpectedFile) {
-            $this->assertFalse($fs->has($notExpectedFile), "$notExpectedFile should NOT exists");
+            $this->assertFalse($fs->fileExists($notExpectedFile), "$notExpectedFile should NOT exists");
         }
     }
 
@@ -1131,12 +1131,12 @@ class AssetStoreTest extends SapphireTest
         $fs = $this->getFilesystem($fsName);
 
         foreach ($expected as $expectedFile) {
-            $this->assertTrue($fs->has($expectedFile), "$expectedFile should exists");
+            $this->assertTrue($fs->fileExists($expectedFile), "$expectedFile should exists");
             $this->assertNotEmpty($fs->read($expectedFile), "$expectedFile should be non empty");
         }
 
         foreach ($notExpected as $notExpectedFile) {
-            $this->assertFalse($fs->has($notExpectedFile), "$notExpectedFile should NOT exists");
+            $this->assertFalse($fs->fileExists($notExpectedFile), "$notExpectedFile should NOT exists");
         }
     }
 

--- a/tests/php/Storage/Sha1FileHashingServiceTest.php
+++ b/tests/php/Storage/Sha1FileHashingServiceTest.php
@@ -2,23 +2,12 @@
 
 namespace SilverStripe\Assets\Tests\Storage;
 
-use Exception;
-use InvalidArgumentException;
-use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
+use League\Flysystem\UnableToReadFile;
 use ReflectionMethod;
-use Silverstripe\Assets\Dev\TestAssetStore;
-use SilverStripe\Assets\File;
-use SilverStripe\Assets\FilenameParsing\FileIDHelper;
-use SilverStripe\Assets\FilenameParsing\HashFileIDHelper;
-use SilverStripe\Assets\FilenameParsing\LegacyFileIDHelper;
-use SilverStripe\Assets\FilenameParsing\NaturalFileIDHelper;
-use SilverStripe\Assets\FilenameParsing\ParsedFileID;
-use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Assets\Storage\FileHashingService;
 use SilverStripe\Assets\Storage\Sha1FileHashingService;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use Symfony\Component\Cache\CacheItem;
@@ -62,8 +51,8 @@ class Sha1FileHashingServiceTest extends SapphireTest
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->publicFs->deleteDir('Sha1FileHashingServiceTest');
-        $this->protectedFs->deleteDir('Sha1FileHashingServiceTest');
+        $this->publicFs->deleteDirectory('Sha1FileHashingServiceTest');
+        $this->protectedFs->deleteDirectory('Sha1FileHashingServiceTest');
     }
 
     public function testComputeFromStream()
@@ -103,7 +92,7 @@ class Sha1FileHashingServiceTest extends SapphireTest
 
     public function testComputeMissingFile()
     {
-        $this->expectException(FileNotFoundException::class);
+        $this->expectException(UnableToReadFile::class);
         $service = new Sha1FileHashingService();
         $service->computeFromFile('missing-file.text', AssetStore::VISIBILITY_PROTECTED);
     }
@@ -150,7 +139,7 @@ class Sha1FileHashingServiceTest extends SapphireTest
         // Our timestamp is accruate to the second, we need to wait a bit to make sure our new timestamp won't be in
         // the same second as the old one.
         sleep(2);
-        $this->publicFs->update($this->fileID, $this->protectedContent);
+        $this->publicFs->write($this->fileID, $this->protectedContent);
 
         $this->assertEquals(
             $this->protectedHash,


### PR DESCRIPTION
## Issue
https://github.com/silverstripe/silverstripe-assets/issues/497

## Description

- Upgrade Flysystem to version 3.0
- Upgrade existing functionality in Asset classes by following provided documentation: 
   - [Upgrade from 1.x](https://flysystem.thephpleague.com/docs/upgrade-from-1.x/);
   - [What is new in Flysystem V2 & V3](https://flysystem.thephpleague.com/docs/what-is-new/) 
- New class `ExtendedFilesystem extends Filesystem` to provide `getAdapter()` method, that was  removed from main `legue/flysystem` `Filesystem` class ([GitHub discussion](https://github.com/thephpleague/flysystem/issues/1285))
- New class `ExtendedLocalFilesystemAdapter extends LocalFilesystemAdapter` to provide `prefixPath` method that replaces `applyPathPrefix` method from removed `abstract class AbstractAdapter` ([GitHub discussion](https://github.com/thephpleague/flysystem/issues/1285#issuecomment-808947630))
- New class `SilverStripe\Assets\Util` to replace removed `League\Flysystem\Util` and implement some of required methods.

## Notes:
- Replace invoke `Filesystem has()` method to more appropriated `directoryExists ` or `fileExists`, since `has` checks both cases `directoryExists ` or `fileExists` and returns `true`, if one of them returns `true`;
- New `listContents` method returns `DirectoryListing`, but previous version returned `array`. For this case, invoke `toArray` method on result to return `array` to support existing functionality.

