### PR TITLE
Deprecate a bunch of legacy file method and tasks

### DIFF
--- a/src/Dev/FixFolderPermissionsHelper.php
+++ b/src/Dev/FixFolderPermissionsHelper.php
@@ -7,6 +7,7 @@ use Psr\Log\NullLogger;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\Security\InheritedPermissionFlusher;
@@ -16,6 +17,9 @@ use SilverStripe\Security\InheritedPermissionFlusher;
  * @see https://github.com/silverstripe/silverstripe-secureassets
  * This helper class resets the `CanViewType` of files that are `NULL`.
  * You need to flush your cache after running this via CLI.
+ *
+ * @deprecated 1.12.0 FixFolderPermissionsHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class FixFolderPermissionsHelper
 {
@@ -30,6 +34,12 @@ class FixFolderPermissionsHelper
 
     public function __construct()
     {
+        Deprecation::notice(
+            '1.12.0',
+            'FixFolderPermissionsHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $this->logger = new NullLogger();
     }
 

--- a/src/Dev/Tasks/FileMigrationHelper.php
+++ b/src/Dev/Tasks/FileMigrationHelper.php
@@ -16,6 +16,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
@@ -27,6 +28,9 @@ use SilverStripe\Versioned\Versioned;
  * Service to help migrate File dataobjects to the new APL.
  *
  * This service does not alter these records in such a way that prevents downgrading back to 3.x
+ *
+ * @deprecated 1.12.0 FileMigrationHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class FileMigrationHelper
 {
@@ -59,6 +63,12 @@ class FileMigrationHelper
 
     public function __construct()
     {
+        Deprecation::notice(
+            '1.12.0',
+            'FileMigrationHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $this->logger = new NullLogger();
     }
 

--- a/src/Dev/Tasks/FolderMigrationHelper.php
+++ b/src/Dev/Tasks/FolderMigrationHelper.php
@@ -9,6 +9,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
@@ -20,7 +21,9 @@ use SilverStripe\Versioned\Versioned;
  *
  * This service does not alter these records in such a way that prevents downgrading back to 3.x
  *
- * @internal This class is not a part of Silverstripe CMS public API
+ * @deprecated 1.12.0 FolderMigrationHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
+ *
  */
 class FolderMigrationHelper
 {
@@ -38,6 +41,12 @@ class FolderMigrationHelper
 
     public function __construct()
     {
+        Deprecation::notice(
+            '1.12.0',
+            'FolderMigrationHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $this->logger = new NullLogger();
     }
 

--- a/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
+++ b/src/Dev/Tasks/LegacyThumbnailMigrationHelper.php
@@ -13,6 +13,7 @@ use SilverStripe\Assets\Folder;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
@@ -37,6 +38,8 @@ use SilverStripe\Versioned\Versioned;
  * - Does not filter out unused CMS thumbnails (they're using a new size now)
  * - Does not move legacy thumbnails to the protected store if the original file
  *   has been unpublished or protected since an earlier 4.x migration run
+ * @deprecated 1.12.0 LegacyThumbnailMigrationHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class LegacyThumbnailMigrationHelper
 {
@@ -52,6 +55,12 @@ class LegacyThumbnailMigrationHelper
 
     public function __construct()
     {
+        Deprecation::notice(
+            '1.12.0',
+            'LegacyThumbnailMigrationHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $this->logger = new NullLogger();
     }
 

--- a/src/Dev/Tasks/NormaliseAccessMigrationHelper.php
+++ b/src/Dev/Tasks/NormaliseAccessMigrationHelper.php
@@ -19,6 +19,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
@@ -28,6 +29,9 @@ use SilverStripe\Versioned\Versioned;
  * the appropriate physical location.
  *
  * This is meant to correct files that got save to the wrong location following the CVE-2019-12245 vulnerability.
+ *
+ * @deprecated 1.12.0 NormaliseAccessMigrationHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class NormaliseAccessMigrationHelper
 {
@@ -88,6 +92,12 @@ class NormaliseAccessMigrationHelper
      */
     public function __construct($base = '')
     {
+        Deprecation::notice(
+            '1.12.0',
+            'NormaliseAccessMigrationHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $this->logger = new NullLogger();
         if ($base) {
             $this->basePath = $base;

--- a/src/Dev/Tasks/SecureAssetsMigrationHelper.php
+++ b/src/Dev/Tasks/SecureAssetsMigrationHelper.php
@@ -10,6 +10,7 @@ use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Queries\SQLSelect;
 
@@ -25,7 +26,8 @@ use SilverStripe\ORM\Queries\SQLSelect;
  *
  * See https://github.com/silverstripe/silverstripe-assets/issues/231
  *
- * @internal
+ * @deprecated 1.12.0 SecureAssetsMigrationHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class SecureAssetsMigrationHelper
 {
@@ -48,6 +50,13 @@ class SecureAssetsMigrationHelper
 
     public function __construct()
     {
+        Deprecation::notice(
+            '1.12.0',
+            'SecureAssetsMigrationHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
+
         $this->logger = new NullLogger();
 
         $this->htaccessRegexes = [

--- a/src/Dev/Tasks/TagsToShortcodeHelper.php
+++ b/src/Dev/Tasks/TagsToShortcodeHelper.php
@@ -17,6 +17,7 @@ use SilverStripe\Core\Environment;
 use SilverStripe\Assets\File;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\ORM\Connect\Query;
 use SilverStripe\ORM\DataObject;
@@ -31,6 +32,8 @@ use SilverStripe\Versioned\Versioned;
  * SS4 and its File Migration Task changes the way in which files are stored in the assets folder, with files placed
  * in subfolders named with partial hashmap values of the file version. This helper class goes through the HTML content
  * fields looking for instances of image links, and corrects the link path to what it should be, with an image shortcode.
+ * @deprecated 1.12.0 TagsToShortcodeHelper will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class TagsToShortcodeHelper
 {
@@ -84,6 +87,12 @@ class TagsToShortcodeHelper
      */
     public function __construct($baseClass = null, $includeBaseClass = false)
     {
+        Deprecation::notice(
+            '1.12.0',
+            'TagsToShortcodeHelper will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
         $flysystemAssetStore = singleton(AssetStore::class);
         if (!($flysystemAssetStore instanceof FlysystemAssetStore)) {
             throw new InvalidArgumentException("FlysystemAssetStore missing");

--- a/src/Dev/Tasks/TagsToShortcodeTask.php
+++ b/src/Dev/Tasks/TagsToShortcodeTask.php
@@ -5,11 +5,14 @@ namespace SilverStripe\Assets\Dev\Tasks;
 use SilverStripe\Assets\Storage\FileHashingService;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * SS4 and its File Migration Task changes the way in which files are stored in the assets folder, with files placed
  * in subfolders named with partial hashmap values of the file version. This build task goes through the HTML content
  * fields looking for instances of image links, and corrects the link path to what it should be, with an image shortcode.
+ * @deprecated 1.12.0 TagsToShortcodeTask will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
  */
 class TagsToShortcodeTask extends BuildTask
 {
@@ -24,6 +27,17 @@ class TagsToShortcodeTask extends BuildTask
 		- baseClass: The base class that will be used to look up HTMLText fields. Defaults to SilverStripe\ORM\DataObject
 		- includeBaseClass: Whether to include the base class' HTMLText fields or not
     ";
+
+    public function __construct()
+    {
+        Deprecation::notice(
+            '1.12.0',
+            'TagsToShortcodeTask will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
+        parent::__construct();
+    }
 
     /**
      * @param \SilverStripe\Control\HTTPRequest $request

--- a/src/Dev/Tasks/VersionedFilesMigrationTask.php
+++ b/src/Dev/Tasks/VersionedFilesMigrationTask.php
@@ -4,7 +4,12 @@ namespace SilverStripe\Assets\Dev\Tasks;
 
 use SilverStripe\Assets\Dev\VersionedFilesMigrator;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\Deprecation;
 
+/**
+ * @deprecated 1.12.0 VersionedFilesMigrationTask will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
+ */
 class VersionedFilesMigrationTask extends BuildTask
 {
     const STRATEGY_DELETE = 'delete';
@@ -15,10 +20,21 @@ class VersionedFilesMigrationTask extends BuildTask
 
     protected $title = 'Migrate versionedfiles';
 
-    protected $description = 'If you had the symbiote/silverstripe-versionedfiles module installed on your 3.x site, it 
+    protected $description = 'If you had the symbiote/silverstripe-versionedfiles module installed on your 3.x site, it
         is no longer needed in 4.x as this functionality is provided by default. This task will remove the old _versions
-        folders or protect them, depending on the strategy you use. Use ?strategy=delete or ?strategy=protect (Apache 
+        folders or protect them, depending on the strategy you use. Use ?strategy=delete or ?strategy=protect (Apache
         only). [Default: delete]';
+
+    public function __construct()
+    {
+        Deprecation::notice(
+            '1.12.0',
+            'VersionedFilesMigrationTask will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
+        parent::__construct();
+    }
 
     /**
      * @param HTTPRequest $request

--- a/src/Dev/VersionedFilesMigrator.php
+++ b/src/Dev/VersionedFilesMigrator.php
@@ -3,16 +3,17 @@
 namespace SilverStripe\Assets\Dev;
 
 use SilverStripe\Assets\Filesystem;
-use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Control\Director;
-use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Path;
-use SilverStripe\Dev\BuildTask;
 use InvalidArgumentException;
+use SilverStripe\Dev\Deprecation;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * @deprecated 1.12.0 VersionedFilesMigrator will not be needed in
+ *   Silverstripe CMS 5. Run the task prior to upgrading your project.
+ */
 class VersionedFilesMigrator
 {
     use Injectable;
@@ -62,6 +63,13 @@ class VersionedFilesMigrator
      */
     public function __construct($strategy = self::STRATEGY_DELETE, $basePath = ASSETS_DIR, $output = true)
     {
+        Deprecation::notice(
+            '1.12.0',
+            'VersionedFilesMigrator will not be needed in Silverstripe CMS 5. ' .
+            'Run the task prior to upgrading your project.',
+            Deprecation::SCOPE_CLASS
+        );
+
         if (!in_array($strategy, [self::STRATEGY_DELETE, self::STRATEGY_PROTECT])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid strategy: %s',

--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -4,8 +4,6 @@ namespace SilverStripe\Assets\FilenameParsing;
 
 /**
  * Helps build and parse Filename Identifiers (ake: FileIDs) according to a predefined format.
- *
- * @internal This is still an evolving API. It may change in the next minor release.
  */
 interface FileIDHelper
 {

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -21,8 +21,6 @@ use SilverStripe\ORM\DB;
  * older file format to resolve.
  *
  * You may also provide a `VersionedStage` to only look at files that were published.
- *
- * @internal This is still an evolving API. It may change in the next minor release.
  */
 class FileIDHelperResolutionStrategy implements FileResolutionStrategy
 {

--- a/src/FilenameParsing/FileResolutionStrategy.php
+++ b/src/FilenameParsing/FileResolutionStrategy.php
@@ -5,8 +5,6 @@ use League\Flysystem\Filesystem;
 
 /**
  * Represents a strategy for resolving files on a Flysystem Adapter.
- *
- * @internal This is still an evolving API. It may change in the next minor release.
  */
 interface FileResolutionStrategy
 {

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -13,8 +13,6 @@ use SilverStripe\Core\Injector\Injectable;
  * SilverStripe 4.4.
  *
  * e.g.: `Uploads/a1312bc34d/sam__ResizedImageWzYwLDgwXQ.jpg`
- *
- * @internal This is still an evolving API. It may change in the next minor release.
  */
 class HashFileIDHelper implements FileIDHelper
 {

--- a/src/FilenameParsing/LegacyFileIDHelper.php
+++ b/src/FilenameParsing/LegacyFileIDHelper.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Assets\FilenameParsing;
 use Exception;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Parsed SS3 style legacy asset URLs. e.g.: `Uploads/_resampled/ResizedImageWzYwLDgwXQ/sam.jpg`
@@ -12,7 +13,7 @@ use SilverStripe\Core\Injector\Injectable;
  * SS3 legacy paths are no longer used in SilverStripe 4, but a way to parse them is needed for redirecting old SS3
  * urls.
  *
- * @internal This is still an evolving API. It may change in the next minor release.
+ * @deprecated 1.12.0 Legacy file names will not be supported in Silverstripe CMS 5
  */
 class LegacyFileIDHelper implements FileIDHelper
 {
@@ -21,7 +22,7 @@ class LegacyFileIDHelper implements FileIDHelper
 
     /**
      * List of SilverStripe 3 image method names that can appear in variants. Prior to SilverStripe 3.3, variants were
-     * incoded in the filename with dashes. e.g.: `_resampled/FitW10-sam.jpg` rather than `_resampled/FitW10/sam.jpg`.
+     * encoded in the filename with dashes. e.g.: `_resampled/FitW10-sam.jpg` rather than `_resampled/FitW10/sam.jpg`.
      * @config
      */
     private static $ss3_image_variant_methods = [
@@ -53,6 +54,7 @@ class LegacyFileIDHelper implements FileIDHelper
      */
     public function __construct($failNewerVariant = true)
     {
+        Deprecation::notice('1.12.0', 'Legacy file names will not be supported in Silverstripe CMS 5', Deprecation::SCOPE_CLASS);
         $this->failNewerVariant = $failNewerVariant;
     }
 

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -11,8 +11,6 @@ use SilverStripe\Core\Injector\Injectable;
  * `legacy_filenames` is enabled.
  *
  * e.g.: `Uploads/sam__ResizedImageWzYwLDgwXQ.jpg`
- *
- * @internal This is still an evolving API. It may changed in the next minor release.
  */
 class NaturalFileIDHelper implements FileIDHelper
 {

--- a/src/FilenameParsing/ParsedFileID.php
+++ b/src/FilenameParsing/ParsedFileID.php
@@ -4,8 +4,6 @@ namespace SilverStripe\Assets\FilenameParsing;
 
 /**
  * Immutable representation of a parsed fileID broken down into its sub-components.
- *
- * @internal This is still an evolving API. It may change in the next minor release.
  */
 class ParsedFileID
 {

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -204,7 +204,6 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     /**
      * @return FileResolutionStrategy
-     * @internal This API has not been formalised yet.
      */
     public function getPublicResolutionStrategy()
     {
@@ -220,7 +219,6 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     /**
      * @param FileResolutionStrategy $publicResolutionStrategy
-     * @internal This API has not been formalised yet.
      */
     public function setPublicResolutionStrategy(FileResolutionStrategy $publicResolutionStrategy)
     {
@@ -230,7 +228,6 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
     /**
      * @return FileResolutionStrategy
      * @throws LogicException
-     * @internal This API has not been formalised yet.
      */
     public function getProtectedResolutionStrategy()
     {
@@ -246,7 +243,6 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     /**
      * @param FileResolutionStrategy $protectedResolutionStrategy
-     * @internal This API has not been formalised yet.
      */
     public function setProtectedResolutionStrategy(FileResolutionStrategy $protectedResolutionStrategy)
     {

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -26,6 +26,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 
@@ -82,7 +83,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * in https://docs.silverstripe.org/en/4/changelogs/4.4.0/
      *
      * @config
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Legacy file names will not be supported in Silverstripe CMS 5
      * @var bool
      */
     private static $legacy_filenames = false;
@@ -256,11 +257,12 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * Return the store that contains the given fileID
      *
      * @param string $fileID Internal file identifier
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `applyToFileIDOnFilesystem()` instead
      * @return Filesystem
      */
     protected function getFilesystemFor($fileID)
     {
+        Deprecation::notice('1.4.0', 'Use `applyToFileIDOnFilesystem()` instead');
         return $this->applyToFileIDOnFilesystem(
             function (ParsedFileID $parsedFileID, Filesystem $fs) {
                 return $fs;
@@ -291,7 +293,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param bool $strictHashCheck
      * @return mixed
      */
-    private function applyToFileOnFilesystem(callable $callable, ParsedFileID $parsedFileID, $strictHashCheck = true)
+    protected function applyToFileOnFilesystem(callable $callable, ParsedFileID $parsedFileID, $strictHashCheck = true)
     {
         $publicSet = [
             $this->getPublicFilesystem(),
@@ -375,7 +377,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param bool $strictHashCheck
      * @return mixed
      */
-    private function applyToFileIDOnFilesystem(callable $callable, $fileID, $strictHashCheck = true)
+    protected function applyToFileIDOnFilesystem(callable $callable, $fileID, $strictHashCheck = true)
     {
         $publicSet = [
             $this->getPublicFilesystem(),
@@ -703,10 +705,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param string $fileID
      * @param Filesystem $filesystem
      * @return bool True if a file was deleted
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `deleteFromFileStore()` instead
      */
     protected function deleteFromFilesystem($fileID, Filesystem $filesystem)
     {
+        Deprecation::notice('1.4.0', 'Use `deleteFromFileStore()` instead');
         $deleted = false;
         foreach ($this->findVariants($fileID, $filesystem) as $nextID) {
             $filesystem->delete($nextID);
@@ -768,9 +771,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param string $fileID ID of original file to compare with.
      * @param Filesystem $filesystem
      * @return Generator
+     * @deprecated 1.12.0 Use `FileResolutionStrategy::findVariants()` instead
      */
     protected function findVariants($fileID, Filesystem $filesystem)
     {
+        Deprecation::notice('1.12.0', 'Use `' . FileResolutionStrategy::class . '::findVariants()` instead');
         $dirname = ltrim(dirname($fileID ?? ''), '.');
         foreach ($filesystem->listContents($dirname) as $next) {
             if ($next['type'] !== 'file') {
@@ -909,10 +914,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @param string $fileID
      * @param Filesystem $from
      * @param Filesystem $to
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `moveBetweenFileStore()` instead
      */
     protected function moveBetweenFilesystems($fileID, Filesystem $from, Filesystem $to)
     {
+        Deprecation::notice('1.4.0', 'Use `moveBetweenFileStore` instead');
         foreach ($this->findVariants($fileID, $from) as $nextID) {
             // Copy via stream
             $stream = $from->readStream($nextID);
@@ -1056,11 +1062,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param resource $stream
      * @return string str1 hash
-     * @deprecated 4.4.0 Use FileHashingService::computeFromStream() instead
+     * @deprecated 1.4.0 Use FileHashingService::computeFromStream() instead
      */
     protected function getStreamSHA1($stream)
     {
-
+        Deprecation::notice('1.4.0', 'Use `' . FileHashingService::class . '::computeFromStream()` instead');
         return Injector::inst()
             ->get(FileHashingService::class)
             ->computeFromStream($stream);
@@ -1220,11 +1226,12 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
     /**
      * Determine if legacy filenames should be used. This no longuer makes any difference with the introduction of
      * FileResolutionStrategies.
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Legacy file names will not be supported in Silverstripe CMS 5
      * @return bool
      */
     protected function useLegacyFilenames()
     {
+        Deprecation::notice('1.4.0', 'Legacy file names will not be supported in Silverstripe CMS 5');
         return $this->config()->get('legacy_filenames');
     }
 
@@ -1348,10 +1355,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param string $filename
      * @return string
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `FileIDHelper::cleanFilename()` instead
      */
     protected function cleanFilename($filename)
     {
+        Deprecation::notice('1.4.0', 'Use `' . FileIDHelper::class . '::cleanFilename()` instead');
         /** @var FileIDHelper $helper */
         $helper = Injector::inst()->get(HashFileIDHelper::class);
         return $helper->cleanFilename($filename);
@@ -1362,10 +1370,11 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param string $fileID
      * @return array
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `FileResolutionStrategy::parseFileID()` instead
      */
     protected function parseFileID($fileID)
     {
+        Deprecation::notice('1.4.0', 'Use `' . FileResolutionStrategy::class . '::parseFileID()` instead');
         /** @var ParsedFileID $parsedFileID */
         $parsedFileID = $this->getProtectedResolutionStrategy()->parseFileID($fileID);
         return $parsedFileID ? $parsedFileID->getTuple() : null;
@@ -1376,10 +1385,18 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param string $fileID Adapter specific identifier for this file/version
      * @return string Filename for this file, omitting hash and variant
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `FileResolutionStrategy::parseFileID()` and `ParsedFileID::getFilename()` instead
      */
     protected function getOriginalFilename($fileID)
     {
+        Deprecation::notice(
+            '1.4.0',
+            'Use `' .
+            FileResolutionStrategy::class .
+            '::parseFileID()` and `' .
+            ParsedFileID::class .
+            '::getFilename()` instead.'
+        );
         $parsedFiledID = $this->getPublicResolutionStrategy()->parseFileID($fileID);
         return $parsedFiledID ? $parsedFiledID->getFilename() : null;
     }
@@ -1389,10 +1406,18 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param string $fileID
      * @return string
-     * @deprecated 1.4.0
+     * @deprecated 1.4.0 Use `FileResolutionStrategy::parseFileID()` and `ParsedFileID::getVariant()` instead
      */
     protected function getVariant($fileID)
     {
+        Deprecation::notice(
+            '1.4.0',
+            'Use `' .
+            FileResolutionStrategy::class .
+            '::parseFileID()` and `' .
+            ParsedFileID::class .
+            '::getVariant()` instead.'
+        );
         $parsedFiledID = $this->getPublicResolutionStrategy()->parseFileID($fileID);
         return $parsedFiledID ? $parsedFiledID->getVariant() : null;
     }
@@ -1402,10 +1427,18 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      *
      * @param string $fileID
      * @return string FileID without variant
-     * @deprecated
+     * @deprecated 1.4.0 Use `FileResolutionStrategy::parseFileID()` and `ParsedFileID::setVariant()` instead
      */
     protected function removeVariant($fileID)
     {
+        Deprecation::notice(
+            '1.4.0',
+            'Use `' .
+            FileResolutionStrategy::class .
+            '::parseFileID()` and `' .
+            ParsedFileID::class .
+            '::setVariant()` instead'
+        );
         $parsedFiledID = $this->getPublicResolutionStrategy()->parseFileID($fileID);
         if ($parsedFiledID) {
             return $this->getPublicResolutionStrategy()->buildFileID($parsedFiledID->setVariant(''));

--- a/src/Storage/FileHashingService.php
+++ b/src/Storage/FileHashingService.php
@@ -9,8 +9,6 @@ use League\Flysystem\Filesystem;
  * Utility for computing and comparing unique file hash. All `$fs` parameters can either be:
  * * an `AssetStore` constant VISIBILITY constant or
  * * an actual `Filesystem` object.
- *
- * @internal This interface is not part of the official SilverStripe API and may be altered in minor releases.
  */
 interface FileHashingService
 {

--- a/src/Storage/Sha1FileHashingService.php
+++ b/src/Storage/Sha1FileHashingService.php
@@ -16,8 +16,6 @@ use SilverStripe\ORM\FieldType\DBDatetime;
  * Utility for computing and comparing unique file hash. All `$fs` parameters can either be:
  * * an `AssetStore` constant VISIBILITY constant or
  * * an actual `Filesystem` object.
- *
- * @internal This interface is not part of the official SilverStripe API and may be altered in minor releases.
  */
 class Sha1FileHashingService implements FileHashingService, Flushable
 {


### PR DESCRIPTION
Around CMS4.4 we/I did a big refactor of the assets system. We have a bunch deah weight code that needs to be removed.

This PR make sure everything throws deprecation warnings.

I've also removed a bunch of `@internal` statement. This is mostly because:
- the replacement method for some of the deprecated method was not officially supported or
- can deprecate a method that is not officially supported.

In the case of the file resolution logic, we didn't want to support it because we wanted the flexibility to change it if it turn out to be have some problem. We haven't had to change anything to it, so it's probably safe to assume to support it at this stage.

## Parent issue
https://github.com/silverstripe/silverstripe-assets/issues/521