### PR TITLE
ENH tidy up InterventionBackend::getImageResource()

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -255,23 +255,7 @@ class InterventionBackend implements Image_Backend, Flushable
         // Handle resource
         $error = self::FAILED_UNKNOWN;
         try {
-            // write the file to a local path so we can extract exif data if it exists.
-            // Currently exif data can only be read from file paths and not streams
-            $tempPath = $this->config()->get('local_temp_path') ?? TEMP_PATH;
-            $path = tempnam($tempPath ?? '', 'interventionimage_');
-            if ($extension = pathinfo($assetContainer->getFilename() ?? '', PATHINFO_EXTENSION)) {
-                //tmpnam creates a file, we should clean it up if we are changing the path name
-                unlink($path ?? '');
-                $path .= "." . $extension;
-            }
-            $bytesWritten = file_put_contents($path ?? '', $stream);
-            // if we fail to write, then load from stream
-            if ($bytesWritten === false) {
-                $resource = $this->getImageManager()->make($stream);
-            } else {
-                $this->setTempPath($path);
-                $resource = $this->getImageManager()->make($path);
-            }
+            $resource = $this->getImageManager()->make($stream);
 
             // Fix image orientation
             try {


### PR DESCRIPTION
Now that our minimum PHP version is >7.2 PHP supports stream based exif data.  Since `intervention/image` 2.6 https://github.com/Intervention/image/commit/3ab514c80461929e9f7010f1dfbf69287beb6fc8 exif data can be extracted from streams so this logic appears no longer required

Link to previous PR for context https://github.com/silverstripe/silverstripe-assets/pull/409