### PR TITLE
FIX Cast absoluteUrl() argument to string

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -869,7 +869,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     {
         $url = $this->getURL();
         if ($url) {
-            return Director::absoluteURL($url);
+            return Director::absoluteURL((string) $url);
         }
         return null;
     }

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -326,7 +326,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
         if (!$this->exists()) {
             return null;
         }
-        return Director::absoluteURL($this->getURL());
+        return Director::absoluteURL((string) $this->getURL());
     }
 
     public function getMetaData()


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

Similar to https://github.com/silverstripe/silverstripe-elemental/pull/1029