### PR TITLE
MNT Make asset variant unit tests order agnostic

### DIFF
--- a/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
+++ b/tests/php/FilenameParsing/FileIDHelperResolutionStrategyTest.php
@@ -530,14 +530,13 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         $variantGenerator = $strategy->findVariants($tuple, $this->fs);
 
         /** @var ParsedFileID $parsedFileID */
+        $c = 0;
         foreach ($variantGenerator as $parsedFileID) {
-            $this->assertNotEmpty($expectedPaths);
-            $expectedPath = array_shift($expectedPaths);
-            $this->assertEquals($expectedPath, $parsedFileID->getFileID());
+            $this->assertTrue(in_array($parsedFileID->getFileID(), $expectedPaths));
             $this->assertEquals('mockedvariant', $parsedFileID->getVariant());
+            $c++;
         }
-
-        $this->assertEmpty($expectedPaths);
+        $this->assertSame(count($expectedPaths), $c);
     }
 
     public function testFindHashlessVariant()
@@ -555,24 +554,23 @@ class FileIDHelperResolutionStrategyTest extends SapphireTest
         );
         $this->fs->write('Folder/FolderFile__mockedvariant.pdf', 'version 1 -- mockedvariant');
 
-        $expectedPaths = [
-            ['Folder/FolderFile.pdf', ''],
-            ['Folder/FolderFile__mockedvariant.pdf', 'mockedvariant']
+        $expectedPathsVariants = [
+            'Folder/FolderFile.pdf|',
+            'Folder/FolderFile__mockedvariant.pdf|mockedvariant'
             // The hash path won't be match, because we're not providing a hash
         ];
 
         $variantGenerator = $strategy->findVariants(new ParsedFileID('Folder/FolderFile.pdf'), $this->fs);
 
+        $c = 0;
         /** @var ParsedFileID $parsedFileID */
         foreach ($variantGenerator as $parsedFileID) {
-            $this->assertNotEmpty($expectedPaths, 'More files were returned than expected');
-            $expectedPath = array_shift($expectedPaths);
-            $this->assertEquals($expectedPath[0], $parsedFileID->getFileID());
-            $this->assertEquals($expectedPath[1], $parsedFileID->getVariant());
+            $pathVariant = implode('|', [$parsedFileID->getFileID(), $parsedFileID->getVariant()]);
+            $this->assertTrue(in_array($pathVariant, $expectedPathsVariants));
             $this->assertEquals($expectedHash, $parsedFileID->getHash());
+            $c++;
         }
-
-        $this->assertEmpty($expectedPaths, "Not all expected files were returned");
+        $this->assertSame(count($expectedPathsVariants), $c);
     }
 
     public function testParseFileID()


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10403

Fixes `1) SilverStripe\Assets\Tests\FilenameParsing\FileIDHelperResolutionStrategyTest::testFindVariant with data set #0 (SilverStripe\Assets\FilenameParsing\FileIDHelperResolutionStrategy Object (...), SilverStripe\Assets\FilenameParsing\ParsedFileID Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Folder/FolderFile.pdf'
+'Folder/SubFolder/SubFolderFile.pdf'`
https://github.com/emteknetnz/silverstripe-installer/actions/runs/3700324160/jobs/6268641143

Possible due to the upgrade of the Flysystem dependency, there is an ordering issue that was attempted to be fixed in https://github.com/silverstripe/silverstripe-assets/commit/349508447b66591671b8930a25cd3fc1f78fb97e#diff-0668b7adbf9e875b66c47d35627b4ed054921175c1c8583e407607e4c4629353R526

From memory this unit test was showing different results on local and CI.  This unit test was failing for me locally as well, so I've made it order agnostic.

I've raised a new issue to further investigate what's going on [here](https://github.com/silverstripe/silverstripe-assets/issues/534)