### PR TITLE
Fix for vips intervention image backend

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -340,7 +340,7 @@ class InterventionBackend implements Image_Backend, Flushable
         if ($image === null) {
             // remove our temp file if it exists
             if (file_exists($this->getTempPath() ?? '')) {
-                unlink($this->getTempPath() ?? '');
+                unlink($this->getTempPath());
             }
         }
         return $this;

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -293,9 +293,6 @@ class InterventionBackend implements Image_Backend, Flushable
             if ($error) {
                 $this->markFailed($hash, $variant, $error);
             }
-            if (isset($path) && file_exists($path)) {
-                unlink($path);
-            }
         }
         return null;
     }

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -172,7 +172,7 @@ class InterventionBackend implements Image_Backend, Flushable
      */
     public function setAssetContainer($assetContainer)
     {
-        $this->image = null;
+        $this->setImageResource(null);
         $this->container = $assetContainer;
         return $this;
     }
@@ -337,6 +337,12 @@ class InterventionBackend implements Image_Backend, Flushable
     public function setImageResource($image)
     {
         $this->image = $image;
+        if ($image === null) {
+            // remove our temp file if it exists
+            if (file_exists($this->getTempPath() ?? '')) {
+                unlink($this->getTempPath() ?? '');
+            }
+        }
         return $this;
     }
 


### PR DESCRIPTION
The vips intervetion image backend isn't working right now, because InterventionBackend unlinks the temporary file too early. It is removed before the actual libvips commands are run against it, which makes them fail. The temporary file is removed in the destructor of InterventionBackend anyway, so this section is unnecessary.