### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
+        "silverstripe/framework": "^4.10",
         "silverstripe/vendor-plugin": "^1.0",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "intervention/image": "^2.7",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33