### PR TITLE
Don't make query if not needed

### DIFF
--- a/src/Shortcodes/FileLinkTracking.php
+++ b/src/Shortcodes/FileLinkTracking.php
@@ -142,6 +142,7 @@ class FileLinkTracking extends DataExtension
             }
         }
 
+        // We cannot rely on linkedPages being empty, because we need to remove them if there was any
         if (!$hasTrackedFields) {
             return;
         }

--- a/src/Shortcodes/FileLinkTracking.php
+++ b/src/Shortcodes/FileLinkTracking.php
@@ -131,13 +131,19 @@ class FileLinkTracking extends DataExtension
         $allFields = DataObject::getSchema()->fieldSpecs($this->owner);
         $linkedPages = [];
         $anyBroken = false;
+        $hasTrackedFields = false;
         foreach ($allFields as $field => $fieldSpec) {
             $fieldObj = $this->owner->dbObject($field);
             if ($fieldObj instanceof DBHTMLText) {
+                $hasTrackedFields = true;
                 // Merge links in this field with global list.
                 $linksInField = $this->trackLinksInField($field, $anyBroken);
                 $linkedPages = array_merge($linkedPages, $linksInField);
             }
+        }
+
+        if (!$hasTrackedFields) {
+            return;
         }
 
         // Soft support for HasBrokenFile db field (e.g. SiteTree)


### PR DESCRIPTION
setByIDList will make a query even though there are no DBHTMLText for this DataObject

Checking the presence of these fields allow to return early and prevent the needless query

Fixes https://github.com/silverstripe/silverstripe-assets/issues/557