### PR TITLE
FIX getCachedMarkup returns NULL instead of string if file doesn't exist

### DIFF
--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -102,6 +102,8 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
             $url = $record->Link();
         }
 
+        $url = $url ?? '';
+
         // build the HTML tag
         if ($content) {
             // build some useful meta-data (file type and size) as data attributes
@@ -139,11 +141,12 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
     protected static function getCachedMarkup($cache, $cacheKey, $arguments): string
     {
         $item = $cache->get($cacheKey);
-        if ($item && !empty($item['filename'])) {
+        $assetStore = Injector::inst()->get(AssetStore::class);
+        if ($item && !empty($item['filename']) && $assetStore->exists($item['filename'], $item['hash'])) {
             // Initiate a protected asset grant if necessary
             $allowSessionGrant = static::getGrant(null, $arguments);
             if ($allowSessionGrant) {
-                Injector::inst()->get(AssetStore::class)->grant($item['filename'], $item['hash']);
+                $assetStore->grant($item['filename'], $item['hash']);
                 return $item['markup'];
             }
         }


### PR DESCRIPTION
## Description
- Check if file exist before return cached link for this file from `getCachedMarkup` method.
- Method `handle_shortcode` should return string.  

## Test steps
- Set `FileShortcodeProvider::allow_session_grant = true`;
- Create new Page or open existing one in CMS;
- Click `Insert Link to a file` in Content field;
- Select any existing file and Save page;
- Remove file from backend or change link in DB record;
- Open Page in CMS again;
- You should not see any Errors;
- Shortcode link should lead to "Home" page;  
 
## Parent issue
- https://github.com/silverstripe/silverstripe-assets/issues/545
