### PR TITLE
FIX getCachedMarkup returns NULL instead of string if file doesn't exist

### DIFF
--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -140,7 +140,7 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
     {
         $item = $cache->get($cacheKey);
         $assetStore = Injector::inst()->get(AssetStore::class);
-        if ($item && !empty($item['filename']) && $item['markup']) {
+        if ($item && $item['markup'] && !empty($item['filename'])) {
             // Initiate a protected asset grant if necessary
             $allowSessionGrant = static::getGrant(null, $arguments);
             if ($allowSessionGrant && $assetStore->exists($item['filename'], $item['hash'])) {

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -139,11 +139,15 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
     protected static function getCachedMarkup($cache, $cacheKey, $arguments): string
     {
         $item = $cache->get($cacheKey);
-        if ($item && !empty($item['filename'])) {
+        $assetStore = Injector::inst()->get(AssetStore::class);
+        if ($item
+            && !empty($item['filename'])
+            && $assetStore->exists($item['filename'], $item['hash'])
+            && $item['markup']) {
             // Initiate a protected asset grant if necessary
             $allowSessionGrant = static::getGrant(null, $arguments);
             if ($allowSessionGrant) {
-                Injector::inst()->get(AssetStore::class)->grant($item['filename'], $item['hash']);
+                $assetStore->grant($item['filename'], $item['hash']);
                 return $item['markup'];
             }
         }

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -140,13 +140,10 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
     {
         $item = $cache->get($cacheKey);
         $assetStore = Injector::inst()->get(AssetStore::class);
-        if ($item
-            && !empty($item['filename'])
-            && $assetStore->exists($item['filename'], $item['hash'])
-            && $item['markup']) {
+        if ($item && !empty($item['filename']) && $item['markup']) {
             // Initiate a protected asset grant if necessary
             $allowSessionGrant = static::getGrant(null, $arguments);
-            if ($allowSessionGrant) {
+            if ($allowSessionGrant && $assetStore->exists($item['filename'], $item['hash'])) {
                 $assetStore->grant($item['filename'], $item['hash']);
                 return $item['markup'];
             }

--- a/tests/php/Shortcodes/FileShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/FileShortcodeProviderTest.php
@@ -149,4 +149,37 @@ class FileShortcodeProviderTest extends SapphireTest
         $parser->parse(sprintf('[file_link,id=%d]', $testFile->ID));
         $this->assertFalse($assetStore->isGranted($testFile));
     }
+
+    public function testMarkupHasStringValue()
+    {
+        $testFile = $this->objFromFixture(File::class, 'asdf');
+        $testFileID = $testFile->ID;
+        $tuple = $testFile->File->getValue();
+
+        $assetStore = Injector::inst()->get(AssetStore::class);
+
+        $parser = new ShortcodeParser();
+        $parser->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);
+
+        FileShortcodeProvider::config()->set('allow_session_grant', true);
+
+        $fileShortcode = sprintf('[file_link,id=%d]', $testFileID);
+        $this->assertEquals(
+            $testFile->Link(),
+            $parser->parse(sprintf('[file_link,id=%d]', $testFileID)),
+            'Test that shortcode with existing file ID is parsed.'
+        );
+
+        $testFile->deleteFile();
+        $this->assertFalse(
+            $assetStore->exists($tuple['Filename'], $tuple['Hash']),
+            'Test that file was removed from Asset store.'
+        );
+
+        $this->assertEquals(
+            '',
+            $parser->parse(sprintf('[file_link,id=%d]', $testFileID)),
+            'Test that shortcode with invalid file ID is not parsed.'
+        );
+    }
 }


### PR DESCRIPTION
## Description
- Check if file exist before return cached link for this file from `getCachedMarkup` method.
- Method `handle_shortcode` should return string.  

## Test steps
- Set `FileShortcodeProvider::allow_session_grant = true`;
- Create new Page or open existing one in CMS;
- Click `Insert Link to a file` in Content field;
- Select any existing file and Save page;
- Remove file from backend or change link in DB record;
- Open Page in CMS again;
- You should not see any Errors;
- Shortcode link should lead to "Home" page;  
 
## Parent issue
- https://github.com/silverstripe/silverstripe-assets/issues/545
