### PR TITLE
Add support for braille format files

### DIFF
--- a/_config/filetypes.yml
+++ b/_config/filetypes.yml
@@ -29,3 +29,4 @@ SilverStripe\Assets\File:
     html: 'HTML file'
     htm: 'HTML file'
     webp: 'WEBP Image'
+    brf: 'Braille ASCII file'

--- a/src/File.php
+++ b/src/File.php
@@ -202,7 +202,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
      * Instructions for the change you need to make are included in a comment in the config file.
      */
     private static $allowed_extensions = [
-        '', 'ace', 'arc', 'arj', 'asf', 'au', 'avi', 'bmp', 'bz2', 'cab', 'cda', 'csv', 'dmg', 'doc',
+        '', 'ace', 'arc', 'arj', 'asf', 'au', 'avi', 'bmp', 'brf', 'bz2', 'cab', 'cda', 'csv', 'dmg', 'doc',
         'docx', 'dotx', 'flv', 'gif', 'gz', 'hqx', 'ico', 'jpeg', 'jpg', 'kml',
         'm4a', 'm4v', 'mid', 'midi', 'mkv', 'mov', 'mp3', 'mp4', 'mpa', 'mpeg', 'mpg', 'ogg', 'ogv', 'pages',
         'pcx', 'pdf', 'png', 'pps', 'ppt', 'pptx', 'potx', 'ra', 'ram', 'rm', 'rtf', 'sit', 'sitx',
@@ -224,7 +224,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
             'ram', 'rm', 'snd', 'wav', 'wma',
         ],
         'document' => [
-            'css', 'csv', 'doc', 'docx', 'dotm', 'dotx', 'htm', 'html', 'js', 'kml', 'pages', 'pdf',
+            'brf', 'css', 'csv', 'doc', 'docx', 'dotm', 'dotx', 'htm', 'html', 'js', 'kml', 'pages', 'pdf',
             'potm', 'potx', 'pps', 'ppt', 'pptx', 'rtf', 'txt', 'xhtml', 'xls', 'xlsx', 'xltm', 'xltx', 'xml',
         ],
         'image' => [

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -477,6 +477,9 @@ class FileTest extends SapphireTest
         $file = $this->objFromFixture(Image::class, 'gif');
         $this->assertEquals("GIF image - good for diagrams", $file->getFileType());
 
+        $file = $this->objFromFixture(File::class, 'brf');
+        $this->assertEquals("Braille ASCII file", $file->getFileType());
+
         $file = $this->objFromFixture(File::class, 'pdf');
         $this->assertEquals("Adobe Acrobat PDF file", $file->getFileType());
 

--- a/tests/php/FileTest.yml
+++ b/tests/php/FileTest.yml
@@ -113,6 +113,10 @@ SilverStripe\Assets\File:
     FileFilename: FileTest.txt
     FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
     Name: FileTest.txt
+  brf:
+    FileFilename: FileTest.brf
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: FileTest.brf
   pdf:
     FileFilename: FileTest.pdf
     FileHash: 55b443b60176235ef09801153cca4e6da7494a0c


### PR DESCRIPTION
This adds support for the [Braille ASCII file format](https://en.wikipedia.org/wiki/Braille_ASCII).

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/573