### PR TITLE
FIX Allow inconclusive mimetypes

### DIFF
--- a/src/Flysystem/LocalFilesystemAdapter.php
+++ b/src/Flysystem/LocalFilesystemAdapter.php
@@ -19,7 +19,8 @@ class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter
         MimeTypeDetector $mimeTypeDetector = null
     ) {
         $this->pathPrefixer = new PathPrefixer($location);
-        parent::__construct($location, $visibility, $writeFlags, $linkHandling, $mimeTypeDetector);
+
+        parent::__construct($location, $visibility, $writeFlags, $linkHandling, $mimeTypeDetector, false, true);
     }
 
     public function prefixPath(string $path): string


### PR DESCRIPTION
I don't want to bump the dependency in a patch release so we can't use a named argument for the new `useInconclusiveMimeTypeFallback` parameter since it isn't available in flysystem until [3.23.0](https://github.com/thephpleague/flysystem/compare/3.22.0...3.23.0).

Passing an extra argument doesn't cause errors so it's safe if the project doesn't have flysystem updated - but passing missing named arguments _does_ cause errors.

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/572