### PR TITLE
NEW Allow file variants with different extensions

### DIFF
--- a/src/FilenameParsing/AbstractFileIDHelper.php
+++ b/src/FilenameParsing/AbstractFileIDHelper.php
@@ -2,11 +2,28 @@
 
 namespace SilverStripe\Assets\FilenameParsing;
 
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Path;
 
 abstract class AbstractFileIDHelper implements FileIDHelper
 {
     use Injectable;
+
+    /**
+     * A variant type for encoding a variant filename with a different extension than the original.
+     */
+    public const EXTENSION_REWRITE_VARIANT = 'ExtRewrite';
+
+    /**
+     * Use the original file's extension
+     */
+    protected const EXTENSION_ORIGINAL = 0;
+
+    /**
+     * Use the variant file's extension
+     */
+    protected const EXTENSION_VARIANT = 1;
 
     public function buildFileID($filename, $hash = null, $variant = null, $cleanfilename = true)
     {
@@ -21,6 +38,10 @@ abstract class AbstractFileIDHelper implements FileIDHelper
         // Since we use double underscore to delimit variants, eradicate them from filename
         if ($cleanfilename) {
             $filename = $this->cleanFilename($filename);
+        }
+
+        if ($variant) {
+            $filename = $this->swapExtension($filename, $variant, self::EXTENSION_VARIANT);
         }
 
         $name = basename($filename ?? '');
@@ -51,6 +72,48 @@ abstract class AbstractFileIDHelper implements FileIDHelper
         }
 
         return $fileID;
+    }
+
+    /**
+     * Get the original file's filename with the extension rewritten to be the same as either the original
+     * or the variant extension.
+     *
+     * @param string $filename Original filename without variant
+     * @param int $extIndex One of self::EXTENSION_ORIGINAL or self::EXTENSION_VARIANT
+     */
+    protected function swapExtension(string $filename, string $variant, int $extIndex): string
+    {
+        // If there's no variant at all, we can rewrite the filenmane
+        if (empty($variant)) {
+            return $filename;
+        }
+
+        // Split variant string in variant list
+        $subVariants = explode('_', $variant);
+
+        // Split our filename into a filename and extension part
+        $fileParts = pathinfo($filename);
+        if (!isset($fileParts['filename']) || !isset($fileParts['extension'])) {
+            return $filename;
+        }
+        $dirname = $fileParts['dirname'] !== '.' ? $fileParts['dirname'] : '';
+        $filenameWithoutExtension = Path::join($dirname, $fileParts['filename']);
+        $extension = $fileParts['extension'];
+
+        // Loop our variant list until we find our special file extension swap variant
+        // Reverse the list first so the variant extension we find is the last extension rewrite variant in a chain
+        $extSwapVariant = preg_quote(self::EXTENSION_REWRITE_VARIANT, '/');
+        foreach (array_reverse($subVariants) as $subVariant) {
+            if (preg_match("/^$extSwapVariant(?<base64>.+)$/", $subVariant, $matches)) {
+                // This array always contain 2 values: The original extension at index 0 and the variant extension at index 1
+                /** @var array $extensionData */
+                $extensionData = Convert::base64url_decode($matches['base64']);
+                $extension = $extensionData[$extIndex];
+                break;
+            }
+        }
+
+        return $filenameWithoutExtension . '.' . $extension;
     }
 
     public function cleanFilename($filename)

--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -7,7 +7,6 @@ namespace SilverStripe\Assets\FilenameParsing;
  */
 interface FileIDHelper
 {
-
     /**
      * Map file tuple (hash, name, variant) to a filename to be used by flysystem
      *

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -30,10 +30,16 @@ class HashFileIDHelper extends AbstractFileIDHelper
         }
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
+        $variant = $matches['variant'] ?: '';
+
+        if ($variant) {
+            $filename = $this->swapExtension($filename, $variant, self::EXTENSION_ORIGINAL);
+        }
+
         return new ParsedFileID(
             $filename,
             $matches['hash'],
-            isset($matches['variant']) ? $matches['variant'] : '',
+            $variant,
             $fileID
         );
     }

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -2,8 +2,6 @@
 
 namespace SilverStripe\Assets\FilenameParsing;
 
-use SilverStripe\Core\Injector\Injectable;
-
 /**
  * Parsed Natural path URLs. Natural path is the same hashless path that appears in the CMS.
  *
@@ -23,10 +21,16 @@ class NaturalFileIDHelper extends AbstractFileIDHelper
         }
 
         $filename = $matches['folder'] . $matches['basename'] . $matches['extension'];
+        $variant = $matches['variant'] ?: '';
+
+        if ($variant) {
+            $filename = $this->swapExtension($filename, $variant, self::EXTENSION_ORIGINAL);
+        }
+
         return new ParsedFileID(
             $filename,
             '',
-            isset($matches['variant']) ? $matches['variant'] : '',
+            $variant,
             $fileID
         );
     }

--- a/src/ImageBackendFactory.php
+++ b/src/ImageBackendFactory.php
@@ -37,9 +37,15 @@ class ImageBackendFactory implements Factory
      */
     public function create($service, array $params = [])
     {
-        /** @var AssetContainer $assetContainer */
+        /** @var AssetContainer|null $assetContainer */
         $assetContainer = reset($params);
-        if (!$assetContainer instanceof AssetContainer) {
+
+        // If no asset container was passed in, create a new uncached image backend
+        if (!$assetContainer) {
+            return $this->creator->create($service, $params);
+        }
+
+        if (!($assetContainer instanceof AssetContainer)) {
             throw new BadMethodCallException("Can only create Image_Backend for " . AssetContainer::class);
         }
 

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -1037,7 +1037,7 @@ trait ImageManipulation
             throw new InvalidArgumentException('Invalid variant name arguments: ' . $variantName);
         }
 
-        return array_merge([$matches['format']], $args[0]);
+        return array_merge([$matches['format']], $args);
     }
 
     /**

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -366,8 +366,10 @@ class InterventionBackend implements Image_Backend, Flushable
                 throw new BadMethodCallException("Cannot write corrupt file to store");
             }
 
+            // Make sure we're using the extension of the variant file, which can differ from the original file
+            $url = $assetStore->getAsURL($filename, $hash, $variant, false);
+            $extension = pathinfo($url, PATHINFO_EXTENSION);
             // Save file
-            $extension = pathinfo($filename ?? '', PATHINFO_EXTENSION);
             $result = $assetStore->setFromString(
                 $resource->encode($extension, $this->getQuality())->getEncoded(),
                 $filename,

--- a/tests/php/ImageTest.php
+++ b/tests/php/ImageTest.php
@@ -419,7 +419,7 @@ abstract class ImageTest extends SapphireTest
         $image = singleton(Image::class);
         $format = 'Pad';
         $args = [331, 313, '222222', 0];
-        $name = $image->variantName($format, $args);
+        $name = $image->variantName($format, ...$args);
         $this->assertEquals(
             array_merge([$format], $args),
             $image->variantParts($name)
@@ -432,7 +432,7 @@ abstract class ImageTest extends SapphireTest
         /** @var Image $image */
         $image = singleton(Image::class);
         $args = ['foo'];
-        $name = $image->variantName('Invalid', $args);
+        $name = $image->variantName('Invalid', ...$args);
         $image->variantParts($name);
     }
 

--- a/tests/php/ImageTest.yml
+++ b/tests/php/ImageTest.yml
@@ -42,3 +42,11 @@ SilverStripe\Assets\Image:
     FileHash: 1b22f41d0d27755f06b77eaa27e074eff84d3019
     Parent: =>SilverStripe\Assets\Folder.folder1
     Name: landscape-to-portrait.jpg
+
+SilverStripe\Assets\File:
+  notImage:
+    Title: This is not an image
+    FileFilename: folder/not-image.txt
+    FileHash: 6ab0df7d967f44e98d4bfa403020c6921a2b46e7
+    Parent: =>SilverStripe\Assets\Folder.folder1
+    Name: not-image.txt


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Provides a low-level API for generating a file variant which has a different extension than the original file.
e.g. could be used for:
- Generating thumbnails for videos/documents/etc
- Converting .png or .jpg to .webp
- Converting .docx to .pdf

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Upload a video file.
1. Upload a document file.
1. Use this code for `PageController`.
    Replace `/var/www/html/.eddev/samples/snickers.jpg` with the absolute path to some arbitrary image file your site can access (or replace that logic with something to actually generate a file from the video - I'm taking some shortcuts in that regard)
    Replace `/var/www/html/.eddev/samples/client-pdf2.pdf` with the absolute path to some arbitrary pdf file your site can access (or replace that logic with something to actually generate a pdf from the document - I'm taking some shortcuts in that regard)
    ```php
    use SilverStripe\Assets\Storage\AssetStore;
    use SilverStripe\Assets\File;
    use SilverStripe\Assets\Image_Backend;
    use SilverStripe\CMS\Controllers\ContentController;
    use SilverStripe\Core\Injector\Injector;
    
    class PageController extends ContentController
    {
        public function getVideoImage()
        {
            $file = File::get()->find('FileFilename:EndsWith', File::get_category_extensions('video'));
            return $file->manipulateExtension('jpg', function (AssetStore $store, string $filename, string $hash, string $variant) {
                $backend = Injector::inst()->create(Image_Backend::class);
                $backend->loadFrom('/var/www/html/.eddev/samples/snickers.jpg');
                $tuple = $backend->writeToStore($store, $filename, $hash, $variant, ['conflict' => AssetStore::CONFLICT_USE_EXISTING]);
                return [$tuple, $backend];
            });
        }

        public function getPdfFromDoc()
        {
            $file = File::get()->find('FileFilename:EndsWith', File::get_category_extensions('document'));
            return $file->manipulateExtension('pdf', function (AssetStore $store, string $filename, string $hash, string $variant) {
                $tuple = $store->setFromString(
                    file_get_contents('/var/www/html/.eddev/samples/client-pdf2.pdf'),
                    $filename,
                    $hash,
                    $variant,
                    ['conflict' => AssetStore::CONFLICT_USE_EXISTING]
                );
                return [$tuple, null];
            });
        }
    }
    ```
1. Add this to a page template:
    ```
    <a href="$VideoImage.ScaleMaxHeight(200).CropHeight(50).Link">Link to the resized, cropped thumbnail</a> - ID=$VideoImage.ID
    <br>
    <a href="$PdfFromDoc.Link">Link to the "converted" pdf</a> - ID=$PdfFromDoc.ID
    ```
1. Visit a page and click on the links.
    - For the image, you should see an appropriately scaled and cropped copy of your dummy thumbnail image.
    - For the pdf, you should see the pdf file you pointed your code to.
    - The URL should be obviously a variant of the original file
    - The displayed ID numbers should be the original file IDs

You can also try the [documentation example](https://github.com/silverstripe/developer-docs/pull/441) of converting one image to another image (e.g. a `.jpg` to `.webp`) and see that it also works correctly, even with chained image manipulations.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-assets/issues/488

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
