### PR TITLE
Align rendering of image genercated by ImageShortCodeProvider with generic Image generation

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -1145,8 +1145,8 @@ trait ImageManipulation
         $attributes = [];
         if ($this->getIsImage()) {
             $attributes = [
-                'width' => $this->getWidth(),
-                'height' => $this->getHeight(),
+                'width' => $this->getWidth() ?: null,
+                'height' => $this->getHeight() ?: null,
                 'alt' => $this->getTitle(),
                 'src' => $this->getURL(false)
             ];
@@ -1171,11 +1171,19 @@ trait ImageManipulation
 
         $attributes = array_merge($defaultAttributes, $this->attributes);
 
-        // We need to suppress the `loading="eager"` attribute after we merge the default attributes
-        if (isset($attributes['loading']) && $attributes['loading'] === 'eager') {
-            unset($attributes['loading']);
-        }
+        if (isset($attributes['loading'])) {
+            // Check if the dimensions for the image have been set
+            $dimensionsUnset = (
+                empty($attributes['width']) ||
+                empty($attributes['height'])
+            );
 
+            // We need to suppress the `loading="eager"` attribute after we merge the default attributes
+            // or if dimensions are not set
+            if ($attributes['loading'] === 'eager' || $dimensionsUnset) {
+                unset($attributes['loading']);
+            }
+        }
         $this->extend('updateAttributes', $attributes);
 
         return $attributes;

--- a/templates/DBFile_download.ss
+++ b/templates/DBFile_download.ss
@@ -1,1 +1,1 @@
-<a href="$URL.ATT" title="$Title" <% if $Basename %>download="$Basename.ATT"<% else %>download<% end_if %>>$Title</a>
+<% include SilverStripe\Assets\Storage\DBFile %>

--- a/templates/DBFile_image.ss
+++ b/templates/DBFile_image.ss
@@ -1,1 +1,1 @@
-<img $AttributesHTML />
+<% include SilverStripe\Assets\Storage\DBFile_Image %>

--- a/templates/SilverStripe/Assets/Shortcodes/ImageShortcodeProvider_Image.ss
+++ b/templates/SilverStripe/Assets/Shortcodes/ImageShortcodeProvider_Image.ss
@@ -1,0 +1,1 @@
+<% include SilverStripe\Assets\Storage\DBFile_Image %>

--- a/templates/SilverStripe/Assets/Storage/DBFile.ss
+++ b/templates/SilverStripe/Assets/Storage/DBFile.ss
@@ -1,0 +1,1 @@
+<a href="$URL.ATT" title="$Title" <% if $Basename %>download="$Basename.ATT"<% else %>download<% end_if %>>$Title</a>

--- a/templates/SilverStripe/Assets/Storage/DBFile_Image.ss
+++ b/templates/SilverStripe/Assets/Storage/DBFile_Image.ss
@@ -1,0 +1,1 @@
+<img $AttributesHTML />

--- a/tests/php/Shortcodes/FileLinkTrackingTest.php
+++ b/tests/php/Shortcodes/FileLinkTrackingTest.php
@@ -78,7 +78,7 @@ class FileLinkTrackingTest extends SapphireTest
 
         // Live and stage pages both have link to public file
         $this->assertStringContainsString(
-            '<img src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
+            '<img alt="" src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
             $page->dbObject('Content')->forTemplate()
         );
         $this->assertStringContainsString(
@@ -91,7 +91,7 @@ class FileLinkTrackingTest extends SapphireTest
             /** @var EditableObject $pageLive */
             $pageLive = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
                 $pageLive->dbObject('Content')->forTemplate()
             );
             $this->assertStringContainsString(
@@ -120,14 +120,14 @@ class FileLinkTrackingTest extends SapphireTest
         // the mocked test location disappears for secure files.
         $page = EditableObject::get()->byID($page->ID);
         $this->assertStringContainsString(
-            '<img src="/assets/5a5ee24e44/renamed-test-file.jpg"',
+            '<img alt="" src="/assets/5a5ee24e44/renamed-test-file.jpg"',
             $page->dbObject('Content')->forTemplate()
         );
         Versioned::withVersionedMode(function () use ($page) {
             Versioned::set_stage(Versioned::LIVE);
             $pageLive = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
                 $pageLive->dbObject('Content')->forTemplate()
             );
         });
@@ -137,14 +137,14 @@ class FileLinkTrackingTest extends SapphireTest
         $image1->publishRecursive();
         $page = EditableObject::get()->byID($page->ID);
         $this->assertStringContainsString(
-            '<img src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
+            '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
             $page->dbObject('Content')->forTemplate()
         );
         Versioned::withVersionedMode(function () use ($page) {
             Versioned::set_stage(Versioned::LIVE);
             $pageLive = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
                 $pageLive->dbObject('Content')->forTemplate()
             );
         });
@@ -153,14 +153,14 @@ class FileLinkTrackingTest extends SapphireTest
         $page->publishRecursive();
         $page = EditableObject::get()->byID($page->ID);
         $this->assertStringContainsString(
-            '<img src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
+            '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
             $page->dbObject('Content')->forTemplate()
         );
         Versioned::withVersionedMode(function () use ($page) {
             Versioned::set_stage(Versioned::LIVE);
             $pageLive = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file.jpg"',
                 $pageLive->dbObject('Content')->forTemplate()
             );
         });
@@ -194,7 +194,7 @@ class FileLinkTrackingTest extends SapphireTest
             Versioned::set_stage(Versioned::LIVE);
             $livePage = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/testscript-test-file.jpg"',
                 $livePage->dbObject('Content')->forTemplate()
             );
         });
@@ -213,7 +213,7 @@ class FileLinkTrackingTest extends SapphireTest
         // Confirm that the correct image is shown in both the draft and live site
         $page = EditableObject::get()->byID($page->ID);
         $this->assertStringContainsString(
-            '<img src="/assets/FileLinkTrackingTest/renamed-test-file-second-time.jpg"',
+            '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file-second-time.jpg"',
             $page->dbObject('Content')->forTemplate()
         );
 
@@ -223,7 +223,7 @@ class FileLinkTrackingTest extends SapphireTest
             Versioned::set_stage(Versioned::LIVE);
             $pageLive = EditableObject::get()->byID($page->ID);
             $this->assertStringContainsString(
-                '<img src="/assets/FileLinkTrackingTest/renamed-test-file-second-time.jpg"',
+                '<img alt="" src="/assets/FileLinkTrackingTest/renamed-test-file-second-time.jpg"',
                 $pageLive->dbObject('Content')->forTemplate()
             );
         });


### PR DESCRIPTION
This PR aligns how ImageShortcodeProvider generates its HTML markup to be aligned with how regular images are generated.

This reduces complexity and makes it easy to customise the HTML markups.

## Parent issue
- https://github.com/silverstripe/.github/issues/230

## Depends on
- https://github.com/silverstripe/silverstripe-framework/pull/11217
  - [Review combined build](https://github.com/creative-commoners/recipe-kitchen-sink/actions/workflows/ci.yml?query=branch%3Apulls%2F5%2Falt-attribute-html)