### PR TITLE
FIX Ensure manipulations start with base file

### DIFF
--- a/src/Conversion/FileConverter.php
+++ b/src/Conversion/FileConverter.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Assets\Conversion;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Assets\Storage\DBFile;
 
 /**
@@ -27,5 +28,5 @@ interface FileConverter
      * @param array $options Any options defined for this converter which should apply to the conversion.
      * @throws FileConverterException if invalid options are passed, or the conversion is not supported or fails.
      */
-    public function convert(DBFile $from, string $toExtension, array $options = []): DBFile;
+    public function convert(DBFile|File $from, string $toExtension, array $options = []): DBFile;
 }

--- a/src/Conversion/FileConverterManager.php
+++ b/src/Conversion/FileConverterManager.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Assets\Conversion;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
@@ -27,7 +28,7 @@ class FileConverterManager
      * Note that if a converter supports the conversion generally but doesn't support these options, that converter will not be used.
      * @throws FileConverterException if the conversion failed or there were no converters available.
      */
-    public function convert(DBFile $from, string $toExtension, array $options = []): DBFile
+    public function convert(DBFile|File $from, string $toExtension, array $options = []): DBFile
     {
         $fromExtension = $from->getExtension();
         foreach (static::config()->get('converters') as $converterClass) {

--- a/src/Conversion/InterventionImageFileConverter.php
+++ b/src/Conversion/InterventionImageFileConverter.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Assets\Conversion;
 
 use Imagick;
 use Intervention\Image\Exception\ImageException;
+use SilverStripe\Assets\File;
 use SilverStripe\Assets\Image_Backend;
 use SilverStripe\Assets\InterventionBackend;
 use SilverStripe\Assets\Storage\AssetStore;
@@ -30,7 +31,7 @@ class InterventionImageFileConverter implements FileConverter
         return $this->supportedByIntervention($fromExtension, $backend) && $this->supportedByIntervention($toExtension, $backend);
     }
 
-    public function convert(DBFile $from, string $toExtension, array $options = []): DBFile
+    public function convert(DBFile|File $from, string $toExtension, array $options = []): DBFile
     {
         // Do some basic validation up front for things we know aren't supported
         $problems = $this->validateOptions($options);

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -721,13 +721,8 @@ trait ImageManipulation
     public function Convert(string $toExtension): ?AssetContainer
     {
         $converter = Injector::inst()->get(FileConverterManager::class);
-        if ($this instanceof File) {
-            $from = $this->File;
-        } elseif ($this instanceof DBFile) {
-            $from = $this;
-        }
         try {
-            return $converter->convert($from, $toExtension);
+            return $converter->convert($this, $toExtension);
         } catch (FileConverterException $e) {
             /** @var LoggerInterface $logger */
             $logger = Injector::inst()->get(LoggerInterface::class . '.errorhandler');

--- a/tests/php/Conversion/FileConversionManagerTest/TestImageConverter.php
+++ b/tests/php/Conversion/FileConversionManagerTest/TestImageConverter.php
@@ -15,9 +15,9 @@ class TestImageConverter implements FileConverter, TestOnly
         return in_array($fromExtension, $formats) && in_array($toExtension, $formats);
     }
 
-    public function convert(DBFile $from, string $toExtension, array $options = []): DBFile
+    public function convert(DBFile|File $from, string $toExtension, array $options = []): DBFile
     {
-        $result = clone $from;
+        $result = ($from instanceof File) ? clone $from->File : clone $from;
         $result->Filename = 'converted.' . $toExtension;
         return $result;
     }

--- a/tests/php/Conversion/FileConversionManagerTest/TestTxtToImageConverter.php
+++ b/tests/php/Conversion/FileConversionManagerTest/TestTxtToImageConverter.php
@@ -15,9 +15,9 @@ class TestTxtToImageConverter implements FileConverter, TestOnly
         return strtolower($fromExtension) === 'txt' && in_array(strtolower($toExtension), $formats);
     }
 
-    public function convert(DBFile $from, string $toExtension, array $options = []): DBFile
+    public function convert(DBFile|File $from, string $toExtension, array $options = []): DBFile
     {
-        $result = clone $from;
+        $result = ($from instanceof File) ? clone $from->File : clone $from;
         $result->Filename = 'converted.' . $toExtension;
         return $result;
     }


### PR DESCRIPTION
It turns out there's some special logic going on in manipulation that needs to take place starting with the `File` record. If you try to use the `DBFile` on its own without first performing a manipulation, the attributes applied to the file won't be passed down to subsequent manipulations.

Changing the API here is fine because it's new API that hasn't been released yet.

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/608