### PR TITLE
NEW Scaffold formfields for File and Image using new API

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -16,6 +16,8 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Core\Resettable;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FileHandleField;
+use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HTMLReadonlyField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
@@ -585,6 +587,19 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         );
         $this->extend('updateCMSFields', $fields);
         return $fields;
+    }
+
+    public function scaffoldFormFieldForHasOne(
+        string $fieldName,
+        ?string $fieldTitle,
+        string $relationName,
+        DataObject $ownerRecord
+    ): FormField&FileHandleField {
+        $field = Injector::inst()->create(FileHandleField::class, $relationName, $fieldTitle);
+        if ($field->hasMethod('setAllowedMaxFileNumber')) {
+            $field->setAllowedMaxFileNumber(1);
+        }
+        return $field;
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -2,6 +2,10 @@
 
 namespace SilverStripe\Assets;
 
+use SilverStripe\Forms\FileHandleField;
+use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\DataObject;
+
 /**
  * Represents an Image
  */
@@ -38,6 +42,17 @@ class Image extends File
     {
         parent::__construct($record, $isSingleton, $queryParams);
         $this->File->setAllowedCategories('image/supported');
+    }
+
+    public function scaffoldFormFieldForHasOne(
+        string $fieldName,
+        ?string $fieldTitle,
+        string $relationName,
+        DataObject $ownerRecord
+    ): FormField&FileHandleField {
+        $field = parent::scaffoldFormFieldForHasOne($fieldName, $fieldTitle, $relationName, $ownerRecord);
+        $field->setAllowedFileCategories('image/supported');
+        return $field;
     }
 
     public function getIsImage()


### PR DESCRIPTION
Uses new API from https://github.com/silverstripe/silverstripe-framework/pull/11269 to scaffold formfields for `Image` and `File` has_one relations.

Note that there's no need to bump the framework dependency here - if installing this with framework 5.1 the old code path will be used instead, but the result will be the same.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11079