### PR TITLE
FIX Respect strict-typing of Factory interface

### DIFF
--- a/src/ImageBackendFactory.php
+++ b/src/ImageBackendFactory.php
@@ -35,7 +35,7 @@ class ImageBackendFactory implements Factory
      * @param array $params The constructor parameters.
      * @return object The created service instances.
      */
-    public function create($service, array $params = [])
+    public function create(string $service, array $params = []): ?Image_Backend
     {
         /** @var AssetContainer|null $assetContainer */
         $assetContainer = reset($params);


### PR DESCRIPTION
Respects the new strict typing in https://github.com/silverstripe/silverstripe-framework/pull/11300
That PR is required for Ci to go green.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11145