### PR TITLE
ENH Don't use keyword "self"

### DIFF
--- a/src/Shortcodes/ImageShortcodeProvider.php
+++ b/src/Shortcodes/ImageShortcodeProvider.php
@@ -136,7 +136,7 @@ class ImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeH
         }
 
         // We're calling renderWith() with an explicit template in case someone wants to use a custom template
-        $markup = $manipulatedRecord->renderWith(self::class . '_Image');
+        $markup = $manipulatedRecord->renderWith(ImageShortcodeProvider::class . '_Image');
 
         // cache it for future reference
         if ($fileFound) {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/actions/runs/10088694351/job/27894872547

> ```
>  Error: Can't use keyword 'self'. Use 'ImageShortcodeProvider' instead.
>  ------ ----------------------------------------------------------------- 
>   Line   Shortcodes/ImageShortcodeProvider.php                            
>  ------ ----------------------------------------------------------------- 
>   139    Can't use keyword 'self'. Use 'ImageShortcodeProvider' instead.  
>  ------ ----------------------------------------------------------------- 
> ```

## Issue
- https://github.com/silverstripe/.github/issues/287