### PR TITLE
MNT Ignore phpstan errors we can't fix

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1070,6 +1070,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         $extension = strtolower(File::get_file_extension($filename) ?? '');
 
         if (isset($file_types[$extension])) {
+            /** @phpstan-ignore translation.key (we need the key to be dynamic here) */
             return _t(
                 __CLASS__ . '.' . ucfirst($extension ?? '') . 'Type',
                 $file_types[$extension]


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/actions/runs/10296493337/job/28497938428
> Can't determine value of first argument to _t(). Use a simpler value.

## Issue
- https://github.com/silverstripe/.github/issues/290