### PR TITLE
API Remove CMSEditLink implementation, rely on superclass instead.

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1426,13 +1426,6 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         return $this->File->canViewFile();
     }
 
-    public function CMSEditLink()
-    {
-        $link = null;
-        $this->extend('updateCMSEditLink', $link);
-        return $link;
-    }
-
     public function PreviewLink($action = null)
     {
         // Since AbsoluteURL can whitelist protected assets,


### PR DESCRIPTION
Relies on changes made in https://github.com/silverstripe/silverstripe-framework/pull/11338

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11258