### PR TITLE
ENH ensure file title constructed from original filename

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -727,18 +727,21 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
 
         // Update title
         if (!$title) {
-            // Generate a readable title, dashes and underscores replaced by whitespace,
-            // and any file extensions removed.
-            $this->setField(
-                'Title',
-                str_replace(['-','_'], ' ', preg_replace('/\.[^.]+$/', '', $name ?? '') ?? '')
-            );
+            $this->setField('Title', File::getNormalisedFileName($name));
         }
 
         // Propagate changes to the AssetStore and update the DBFile field
         $this->updateFilesystem();
 
         parent::onBeforeWrite();
+    }
+
+    /**
+     * Generate a readable title, dashes and underscores replaced by whitespace, and any file extensions removed.
+     */
+    public static function getNormalisedFileName(string $name): string
+    {
+        return trim(str_replace(['-','_'], ' ', (string) preg_replace('/\.[^.]+$/', '', $name)));
     }
 
     /**

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -199,6 +199,9 @@ class Upload extends Controller
         }
         $filename = $this->resolveExistingFile($filename);
 
+        // Store teh actual file name before any transformation from getValidFilename
+        $this->file->setField('Title', File::getNormalisedFileName((string) $tmpFile['name']));
+
         // Save changes to underlying record (if it's a DataObject)
         $this->storeTempFile($tmpFile, $filename, $this->file);
         if ($this->file instanceof DataObject) {

--- a/tests/php/FileTest.yml
+++ b/tests/php/FileTest.yml
@@ -170,3 +170,7 @@ SilverStripe\Assets\Image:
     FileFilename: FileTest.png
     FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
     Name: FileTest.png
+  setfromname-non-english:
+    FileFilename: FileTest-ملف.png
+    FileHash: 55b443b60176235ef09801153cca4e6da7494a0c
+    Name: FileTest.png

--- a/tests/php/UploadTest.php
+++ b/tests/php/UploadTest.php
@@ -61,7 +61,7 @@ class UploadTest extends SapphireTest
     public function testUpload()
     {
         // create tmp file
-        $tmpFileName = 'UploadTest-testUpload.txt';
+        $tmpFileName = 'UploadTest-testUploãd.txt';
         $this->tmpFilePath = TEMP_PATH . DIRECTORY_SEPARATOR . $tmpFileName;
         $tmpFileContent = $this->getTemporaryFileContent();
         file_put_contents($this->tmpFilePath ?? '', $tmpFileContent);
@@ -87,6 +87,7 @@ class UploadTest extends SapphireTest
             'Uploads/UploadTest-testUpload.txt',
             $file1->getFilename()
         );
+        $this->assertSame('UploadTest testUploãd', $file1->Title);
         $this->assertEquals(
             ASSETS_PATH . '/UploadTest/.protected/Uploads/315ae4c3d4/UploadTest-testUpload.txt',
             TestAssetStore::getLocalPath($file1)


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
When uploading a file that uses a characters other than English letters, the codebase is going to santise the file name and rename it, this going to change filename from `الطالب لعائلتك.docx` to something which features digital characters, for instance `66b034bf7ca15.docx`. When the `File` object is saved, the new file name is used to populate the `Title` field. 

This PR is to ensure the `Title` field is populated from the original file name  `الطالب لعائلتك.docx` instead of the new name `66b034bf7ca15.docx`

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
- Get a sample file which features Arabic characters in its file name. For instance الطالب لعائلتك.docx.
- In the CMS, go to the "Files" area and upload the file mentioned in the previous step
- When this file is uploaded, you should see the Filename change from الطالب لعائلتك.docx to something which features digital characters, for instance 66b034bf7ca15.docx.
- The title should reflect the original filename.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-assets/issues/624

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
