### PR TITLE
DEP Add league/flysystem-local to fix test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "silverstripe/vendor-plugin": "^2",
         "symfony/filesystem": "^7.0",
         "intervention/image": "^3.7",
-        "league/flysystem": "^3.15.0"
+        "league/flysystem": "^3.22",
+        "league/flysystem-local": "^3.22"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4",


### PR DESCRIPTION
Turns out the changes to https://github.com/silverstripe/silverstripe-assets/pull/644 weren't sufficient - I must have had a more recent version of `league/flysystem-local` in my local while testing it.

We need to add this as an explicit dependency because `league/flysystem` has a lower dependency against it than what we need. Note that `league/flysystem` also had to be bumped, because `league/flysystem-local` doesn't work with lower versions of it (despite not declaring that in its constraints)

See [the changes added in that version](https://github.com/thephpleague/flysystem-local/compare/3.21.0...3.22.0) which include changes to mimetype detection.

I ran this through [asset admin CI](https://github.com/creative-commoners/silverstripe-asset-admin/actions/runs/10892464728) this time around

## Issue
- https://github.com/silverstripe/silverstripe-asset-admin/issues/1496