### PR TITLE
API Rename method

### DIFF
--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -454,7 +454,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
     protected function assertFilenameValid(string $filename): void
     {
         $result = new ValidationResult();
-        $this->validate($result, $filename);
+        $this->validateFilename($result, $filename);
         if (!$result->isValid()) {
             throw new ValidationException($result);
         }
@@ -466,7 +466,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
      *
      * @param null|string $filename Optional filename to validate. If omitted, the current value is validated.
      */
-    public function validate(ValidationResult $result, ?string $filename = null): bool
+    public function validateFilename(ValidationResult $result, ?string $filename = null): bool
     {
         if (empty($filename)) {
             $filename = $this->getFilename();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11391

validate() collides with the new DBField::validate() method