### PR TITLE
FIX Use renamed validate method

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1180,7 +1180,7 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     public function validate()
     {
         $result = ValidationResult::create();
-        $this->File->validate($result, $this->Name);
+        $this->File->validateFilename($result, $this->Name);
         $this->extend('updateValidate', $result);
         return $result;
     }

--- a/src/Storage/DBFile.php
+++ b/src/Storage/DBFile.php
@@ -455,7 +455,7 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail
     protected function assertFilenameValid(string $filename): void
     {
         $result = new ValidationResult();
-        $this->validate($result, $filename);
+        $this->validateFilename($result, $filename);
         if (!$result->isValid()) {
             throw new ValidationException($result);
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11403

Note that the deprecated validate() method was removed on [merge-up](https://github.com/silverstripe/silverstripe-assets/commit/a237a6c8cbbf2dcef5602b2f1b06615409542693) when it shouldn't have been