### PR TITLE
API Use class from new template engine module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
+        "silverstripe/template-engine": "^1",
         "silverstripe/vendor-plugin": "^2",
         "symfony/filesystem": "^7.0",
         "intervention/image": "^3.7",

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -18,7 +18,7 @@ use SilverStripe\Model\ArrayData;
 use SilverStripe\View\HTML;
 use SilverStripe\View\Parsers\ShortcodeHandler;
 use SilverStripe\View\Parsers\ShortcodeParser;
-use SilverStripe\View\SSTemplateEngine;
+use SilverStripe\TemplateEngine\SSTemplateEngine;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\ViewLayerData;
 

--- a/tests/php/ImageManipulationTest.php
+++ b/tests/php/ImageManipulationTest.php
@@ -23,7 +23,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use PHPUnit\Framework\Attributes\DataProvider;
-use SilverStripe\View\SSTemplateEngine;
+use SilverStripe\TemplateEngine\SSTemplateEngine;
 use SilverStripe\View\ViewLayerData;
 
 /**


### PR DESCRIPTION
The template engine code is in its own module now, so we need to add it as a dependency and update the use statement. Going with `API` since that feels like it takes precedence over `DEP` and updating a `use` statement feels like a `API` commit to me, but I'm happy to change the prefix if the reviewer wants me to.

I couldn't think of a clean way to easily abstract this out, given it intentionally uses the same configuration that template partial caching uses, and that is a concept specific to ss templates that can't be abstracted to be for generic template engines.

I think it's sensible to leave this as a strict dependency for now given we have strong coupling to this template engine for all of the CMS templates anyway. If we ever make a move to decouple from the module, we can take another look here at that time - that would need to happen in a future major release anyway since it would mean (at a minimum) moving our CMS templates out of their current modules.



CI for this can't go green until https://github.com/silverstripe/silverstripe-framework/pull/11451 has been merged

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322