### PR TITLE
check temp path before deleting files in __destruct to avoid Object Injection

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -815,7 +815,7 @@ class InterventionBackend implements Image_Backend, Flushable
             $this->image->destroy();
         }
         // remove our temp file if it exists
-        if ((strpos(basename($this->getTempPath()), 'interventionimage_') === 0) && file_exists($this->getTempPath() ?? '')) {
+        if (str_starts_with(basename($this->getTempPath()), 'interventionimage_') && file_exists($this->getTempPath() ?? '')) {
             unlink($this->getTempPath() ?? '');
         }
     }

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -815,7 +815,7 @@ class InterventionBackend implements Image_Backend, Flushable
             $this->image->destroy();
         }
         // remove our temp file if it exists
-        if (file_exists($this->getTempPath() ?? '')) {
+        if ((strpos(basename($this->getTempPath()), 'interventionimage_') === 0) && file_exists($this->getTempPath() ?? '')) {
             unlink($this->getTempPath() ?? '');
         }
     }

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -36,6 +36,11 @@ class InterventionBackend implements Image_Backend, Flushable
     const CACHE_DIMENSIONS = 'DIMENSIONS_';
 
     /**
+     * Prefix for temp file names
+     */
+    private const TEMP_FILE_PREFIX = 'interventionimage_';
+
+    /**
      * Is cache flushing enabled?
      *
      * @config
@@ -258,7 +263,7 @@ class InterventionBackend implements Image_Backend, Flushable
             // write the file to a local path so we can extract exif data if it exists.
             // Currently exif data can only be read from file paths and not streams
             $tempPath = $this->config()->get('local_temp_path') ?? TEMP_PATH;
-            $path = tempnam($tempPath ?? '', 'interventionimage_');
+            $path = tempnam($tempPath ?? '', TEMP_FILE_PREFIX);
             if ($extension = pathinfo($assetContainer->getFilename() ?? '', PATHINFO_EXTENSION)) {
                 //tmpnam creates a file, we should clean it up if we are changing the path name
                 unlink($path ?? '');
@@ -815,7 +820,7 @@ class InterventionBackend implements Image_Backend, Flushable
             $this->image->destroy();
         }
         // remove our temp file if it exists
-        if (str_starts_with(basename($this->getTempPath()), 'interventionimage_') && file_exists($this->getTempPath() ?? '')) {
+        if (str_starts_with(basename($this->getTempPath()), TEMP_FILE_PREFIX) && file_exists($this->getTempPath() ?? '')) {
             unlink($this->getTempPath() ?? '');
         }
     }

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -263,7 +263,7 @@ class InterventionBackend implements Image_Backend, Flushable
             // write the file to a local path so we can extract exif data if it exists.
             // Currently exif data can only be read from file paths and not streams
             $tempPath = $this->config()->get('local_temp_path') ?? TEMP_PATH;
-            $path = tempnam($tempPath ?? '', TEMP_FILE_PREFIX);
+            $path = tempnam($tempPath ?? '', InterventionBackend::TEMP_FILE_PREFIX);
             if ($extension = pathinfo($assetContainer->getFilename() ?? '', PATHINFO_EXTENSION)) {
                 //tmpnam creates a file, we should clean it up if we are changing the path name
                 unlink($path ?? '');

--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -820,8 +820,10 @@ class InterventionBackend implements Image_Backend, Flushable
             $this->image->destroy();
         }
         // remove our temp file if it exists
-        if (str_starts_with(basename($this->getTempPath()), TEMP_FILE_PREFIX) && file_exists($this->getTempPath() ?? '')) {
-            unlink($this->getTempPath() ?? '');
+        $tempPath = $this->getTempPath() ?? '';
+        if (str_starts_with(basename($tempPath), InterventionBackend::TEMP_FILE_PREFIX) && file_exists($tempPath)) {
+            unlink($tempPath);
+        }
         }
     }
 


### PR DESCRIPTION
## Description

See https://github.com/silverstripe/silverstripe-assets/issues/663

## Manual testing steps

You can test this manually via cli in various ways, or by doing something crude like adding this to the end of the main index.php

```
if (isset($_GET['payload'])) {
  unserialize(urldecode($_GET['payload']));
}
```

This simulates a PHP Object Injection vulnerability.

You can then pass the payload as a query param, and check whether the target file has been deleted.

e.g. here's a urlencoded payload to remove a test file called now_you_see_me.txt in the docroot:

```
curl -si http://silverstripe.ddev.site/?payload=O%3A39%3A%22SilverStripe%5CAssets%5CInterventionBackend%22%3A1%3A%7Bs%3A49%3A%22%00SilverStripe%5CAssets%5CInterventionBackend%00tempPath%22%3Bs%3A18%3A%22now_you_see_me.txt%22%3B%7D
```

## Issues

- #663

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
