### PR TITLE
FIX Return null early if there is no file to convert

### DIFF
--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -720,6 +720,10 @@ trait ImageManipulation
      */
     public function Convert(string $toExtension): ?AssetContainer
     {
+        // Verify this manipulation is applicable to this instance
+        if (!$this->exists()) {
+            return null;
+        }
         $converter = Injector::inst()->get(FileConverterManager::class);
         try {
             return $converter->convert($this, $toExtension);

--- a/tests/php/ImageManipulationTest.php
+++ b/tests/php/ImageManipulationTest.php
@@ -606,6 +606,12 @@ class ImageManipulationTest extends SapphireTest
         }
     }
 
+    public function testConvertEmpty(): void
+    {
+        $file = new Image();
+        $this->assertNull($file->Convert('webp'));
+    }
+
     public function provideConvertChainWithLazyLoad(): array
     {
         return [


### PR DESCRIPTION
Resolves the specific problem of not returning null when there is no file to convert with the solution described in https://github.com/silverstripe/silverstripe-assets/issues/656#issuecomment-2540352084
Note that this is the same solution found in `ImageManupulation::manipulate()` which other manipulations such as `Fill()` use.

This scenario occurs when trying to convert a file from a `has_one` relation, where there is no record stored in that `has_one`, since an empty record is returned instead of null from the magic has one method.

Actually changing the logging for other failure scenarios will be handled in https://github.com/silverstripe/silverstripe-framework/issues/11511 in 5.4

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/656
