### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "php": "^8.3",
         "silverstripe/framework": "^6",
         "silverstripe/template-engine": "^1",
-        "silverstripe/vendor-plugin": "^2",
         "symfony/filesystem": "^7.0",
         "intervention/image": "^3.9",
         "league/flysystem": "^3.29",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311