### PR TITLE
fix: Don't add the same extension multiple times

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -1479,6 +1479,11 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
                 continue;
             }
 
+            // don't add the same extension multiple times
+            if (in_array($key, $allowedExtensions)) {
+                continue;
+            }
+
             $allowedExtensions[] = $key;
         }
         return $allowedExtensions;


### PR DESCRIPTION
## Description
This stops the `File::getAllowedExtensions()` function from returning the same extension multiple times.

## Manual testing steps
See test repo:
https://github.com/PortableSteve/ss-assets-test

## Issues
https://github.com/silverstripe/silverstripe-assets/issues/658

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
