### PR TITLE
FIX: ensure  children keep the same visibility when writing folder

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -294,7 +294,12 @@ class Folder extends File
         $this->flushCache();
         // Writing this record should trigger a write (and potential updateFilesystem) on each child
         foreach ($this->AllChildren() as $child) {
+            $isPublished = $child->IsPublished();
+            $isModifiedOnDraft = $child->IsModifiedOnDraft();
             $child->write();
+            if ($isPublished && !$isModifiedOnDraft) {
+                $child->publishSingle();
+            }
         }
     }
 


### PR DESCRIPTION
## Description

When you write a folder (in my case I was setting up default folders using the requireDefaultRecords method), it also write all its children.  

For some reason, when you extend the File (e.g. Document extends File), this start behaving differently. With this extension, if a file is in a folder, and you write the folder, the file becomes "protected" (or at least modified on draft). 

The code is here:
https://github.com/silverstripe/silverstripe-assets/blob/2/src/Folder.php#L296-L298

This is called from `onAfterWrite` and also from `onAfterSkippedWrite` (akin to an onBeforeWrite). 

## Manual testing steps
1. install Silverstripe
2. extend File like this: `class Document extends File`
3. Add at least one DB field to Document (e.g. Content => 'HTMLText")
4. Upload a file in the folder.  Change the file class to be Document (e.g. using onBeforeWrite). 
5. save the parent folder
6. Check the versioned status of the file, it should now be "changed" to draft. 


## Issues
Here are a couple of issues that may relate: 

- https://github.com/silverstripe/silverstripe-assets/issues/681
- https://github.com/silverstripe/silverstripe-assets/issues/385
- https://github.com/silverstripe/silverstripe-assets/issues/304


## Pull request checklist

- [✔] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [✔] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [✔] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [✔] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [✔] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [❌] This change is covered with tests (or tests aren't necessary for this change)
- [❌] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [❌] CI is green
