### PR TITLE
ENH Improve performance of directory truncation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "silverstripe/framework": "^6",
         "silverstripe/template-engine": "^1",
         "symfony/filesystem": "^7.0",
+        "symfony/finder": "^7.0",
         "intervention/image": "^3.9",
         "league/flysystem": "^3.29",
         "league/flysystem-local": "^3.29"

--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -11,7 +11,7 @@ interface FileIDHelper
      * The string that separates the base file name from the variant name.
      * This string must not be present in the name of files which are not variants.
      */
-    public const VARIANT_SEPARATOR = '__';
+    public const string VARIANT_SEPARATOR = '__';
 
     /**
      * Map file tuple (hash, name, variant) to a filename to be used by flysystem

--- a/src/FilenameParsing/FileIDHelperResolutionStrategy.php
+++ b/src/FilenameParsing/FileIDHelperResolutionStrategy.php
@@ -11,6 +11,8 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Assets\File;
+use SilverStripe\Assets\Flysystem\GlobContentLister;
+use SilverStripe\Core\Path;
 use SilverStripe\ORM\DB;
 
 /**
@@ -432,10 +434,24 @@ class FileIDHelperResolutionStrategy implements FileResolutionStrategy
             // Make sure our yield file has an hash
             $hash = $parsedFileID->getHash() ?: $this->findHashOf($helper, $parsedFileID, $filesystem);
 
-
             // Find the correct folder to search for possible variants in
             $folder = $helper->lookForVariantIn($parsedFileID);
-            $possibleVariantsGenerator = $filesystem->listContents($folder, $helper->lookForVariantRecursive());
+
+            if (!$filesystem->directoryExists($folder)) {
+                continue;
+            }
+
+            // Use a glob if possible, as that will be more performant if the adapter supports it.
+            if (($helper instanceof GlobbableFileIDHelper) && ($filesystem instanceof GlobContentLister)) {
+                $glob = $helper->getVariantGlob($folder, $parsedFileID);
+                $possibleVariantsGenerator = $filesystem->listContentsByGlob(
+                    $folder,
+                    $glob,
+                    $helper->lookForVariantRecursive()
+                );
+            } else {
+                $possibleVariantsGenerator = $filesystem->listContents($folder, $helper->lookForVariantRecursive());
+            }
 
             // Flysystem returns generator of meta data abouch each file, we remove directories and map it down to the path
             $possibleVariantPaths = $possibleVariantsGenerator

--- a/src/FilenameParsing/GlobbableFileIDHelper.php
+++ b/src/FilenameParsing/GlobbableFileIDHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Assets\FilenameParsing;
+
+/**
+ * @deprecated 3.1.0 Will be part of the SilverStripe\Assets\FilenameParsing\FileIDHelper interface in a future major release.
+ */
+interface GlobbableFileIDHelper
+{
+    /**
+     * Get the glob for this file for use in GlobContentLister::listContentsByGlob()
+     */
+    public function getVariantGlob(string $folder, ParsedFileID $parsedFileID): string;
+}

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Assets\FilenameParsing;
 
 use InvalidArgumentException;
+use SilverStripe\Assets\File;
 
 /**
  * Parsed Hash path URLs. Hash paths group a file and its variant under a directory based on a hash generated from the
@@ -13,7 +14,7 @@ use InvalidArgumentException;
  *
  * e.g.: `Uploads/a1312bc34d/sam__ResizedImageWzYwLDgwXQ.jpg`
  */
-class HashFileIDHelper extends AbstractFileIDHelper
+class HashFileIDHelper extends AbstractFileIDHelper implements GlobbableFileIDHelper
 {
     /**
      * Default length at which hashes are truncated.
@@ -63,6 +64,17 @@ class HashFileIDHelper extends AbstractFileIDHelper
             $folder .= '/';
         }
         return  $folder . $this->truncate($parsedFileID->getHash());
+    }
+
+    public function getVariantGlob(string $folder, ParsedFileID $parsedFileID): string
+    {
+        $truncatedHash = $this->truncate($parsedFileID->getHash());
+        $folderWithoutHash = str_replace('/' . $truncatedHash, '', $folder);
+        $folderRegex = '#^' . preg_quote($folderWithoutHash, '#') . '/#';
+        $globFilePath = preg_replace($folderRegex, '', $parsedFileID->getFilename());
+        $extRegex = '#\.' . preg_quote(File::get_file_extension($globFilePath), '#') . '$#';
+        $globFilePathWithoutExtension = preg_replace($extRegex, '', $globFilePath);
+        return $globFilePathWithoutExtension . FileIDHelper::VARIANT_SEPARATOR . '*';
     }
 
     protected function validateFileParts($filename, $hash, $variant): void

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Assets\FilenameParsing;
 
+use SilverStripe\Assets\File;
+
 /**
  * Parsed Natural path URLs. Natural path is the same hashless path that appears in the CMS.
  *
@@ -9,7 +11,7 @@ namespace SilverStripe\Assets\FilenameParsing;
  *
  * e.g.: `Uploads/sam__ResizedImageWzYwLDgwXQ.jpg`
  */
-class NaturalFileIDHelper extends AbstractFileIDHelper
+class NaturalFileIDHelper extends AbstractFileIDHelper implements GlobbableFileIDHelper
 {
     public function parseFileID($fileID)
     {
@@ -47,6 +49,15 @@ class NaturalFileIDHelper extends AbstractFileIDHelper
     {
         $folder = dirname($parsedFileID->getFilename() ?? '');
         return $folder == '.' ? '' : $folder;
+    }
+
+    public function getVariantGlob(string $folder, ParsedFileID $parsedFileID): string
+    {
+        $folderRegex = '#^' . preg_quote($folder, '#') . '/#';
+        $globFilePath = preg_replace($folderRegex, '', $parsedFileID->getFilename());
+        $extRegex = '#\.' . preg_quote(File::get_file_extension($globFilePath), '#') . '$#';
+        $globFilePathWithoutExtension = preg_replace($extRegex, '', $globFilePath);
+        return $globFilePathWithoutExtension . FileIDHelper::VARIANT_SEPARATOR . '*';
     }
 
     protected function getFileIDBase($shortFilename, $fullFilename, $hash, $variant): string

--- a/src/Flysystem/Filesystem.php
+++ b/src/Flysystem/Filesystem.php
@@ -2,12 +2,19 @@
 
 namespace SilverStripe\Assets\Flysystem;
 
+use Generator;
+use League\Flysystem\DirectoryListing;
 use League\Flysystem\Filesystem as LeagueFilesystem;
 use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemReader;
 use League\Flysystem\PathNormalizer;
+use League\Flysystem\StorageAttributes;
+use League\Flysystem\UnableToListContents;
 use League\Flysystem\WhitespacePathNormalizer;
+use Symfony\Component\Finder\Glob;
+use Throwable;
 
-class Filesystem extends LeagueFilesystem
+class Filesystem extends LeagueFilesystem implements GlobContentLister
 {
     private $adapter;
     private PathNormalizer $pathNormalizer;
@@ -32,5 +39,65 @@ class Filesystem extends LeagueFilesystem
         $path = $this->pathNormalizer->normalizePath($location);
 
         return strlen($path) === 0 ? false : ($this->getAdapter()->fileExists($path) || $this->getAdapter()->directoryExists($path));
+    }
+
+    /**
+     * Check if a directory is empty
+     */
+    public function isEmpty(string $location): bool
+    {
+        // listContents() uses generators, so we can start the iterator and return false if there's a single item.
+        // In most cases this will be orders of magnitude faster than checking if $this->listContents($location)->toArray() is empty.
+        foreach ($this->listContents($location) as $item) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return DirectoryListing<StorageAttributes>
+     **/
+    public function listContentsByGlob(string $folder, string $fileGlob, bool $deep = FilesystemReader::LIST_SHALLOW): DirectoryListing
+    {
+        $path = $this->pathNormalizer->normalizePath($folder);
+        if ($this->adapter instanceof GlobContentLister) {
+            $listing = $this->adapter->listContentsByGlob($path, $fileGlob, $deep);
+            return new DirectoryListing($this->pipeListing($folder, $deep, $listing));
+        }
+
+        // If the adapter isn't a GlobContentLister, we have to filter by glob after fetching the content.
+        // Use regex to match the found file paths against the glob pattern.
+        // Regex starts with folder location
+        $globRegex = '#^' . rtrim(preg_quote($path, '#'), '/') . '/';
+        // Allow any number of subdirs if checking recursively
+        if ($deep) {
+            $globRegex .= '.*/?';
+        }
+        // Convert original file glob to regex and make sure any period is escaped
+        // Asset file names shouldn't contain any special regex characters other than period so this should be safe.
+        $globRegex .= ltrim(Glob::toRegex($fileGlob, false, true, '#'), '#^');
+        $listing = $this->adapter->listContents($path, $deep);
+        return new DirectoryListing($this->pipeListing(
+            $folder,
+            $deep,
+            $listing,
+            fn (StorageAttributes $item): bool => preg_match($globRegex, $item->path())
+        ));
+    }
+
+    /**
+     * Copied from parent::pipeListing but with the addition of an optional filter
+     */
+    private function pipeListing(string $location, bool $deep, iterable $listing, ?callable $filter = null): Generator
+    {
+        try {
+            foreach ($listing as $item) {
+                if ($filter === null || $filter($item)) {
+                    yield $item;
+                }
+            }
+        } catch (Throwable $exception) {
+            throw UnableToListContents::atLocation($location, $deep, $exception);
+        }
     }
 }

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -692,7 +692,7 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
         if ($dirname
             && ltrim($dirname ?? '', '.')
             && !$this->config()->get('keep_empty_dirs')
-            && !$filesystem->listContents($dirname)->toArray()
+            && $filesystem->isEmpty($dirname)
         ) {
             $filesystem->deleteDirectory($dirname);
             $this->truncateDirectory(dirname($dirname ?? ''), $filesystem);

--- a/src/Flysystem/GlobContentLister.php
+++ b/src/Flysystem/GlobContentLister.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Assets\Flysystem;
+
+use League\Flysystem\FilesystemReader;
+use League\Flysystem\StorageAttributes;
+
+/**
+ * Filesystem or adapter that can list contents using a glob.
+ */
+interface GlobContentLister
+{
+    /**
+     * List the contents of a path by glob.
+     *
+     * For adapters, this must apply the glob as a filter at the point of fetch, i.e. it cannot filter by glob after
+     * contents have been fetched. The purpose of this method is to be more efficient than filtering after fetching
+     * content.
+     *
+     * @return iterable<StorageAttributes>
+     */
+    public function listContentsByGlob(string $folder, string $fileGlob, bool $deep = FilesystemReader::LIST_SHALLOW): iterable;
+}

--- a/src/Flysystem/LocalFilesystemAdapter.php
+++ b/src/Flysystem/LocalFilesystemAdapter.php
@@ -2,14 +2,32 @@
 
 namespace SilverStripe\Assets\Flysystem;
 
+use FilesystemIterator;
+use Generator;
+use GlobIterator;
+use League\Flysystem\DirectoryAttributes;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemReader;
 use League\Flysystem\Local\LocalFilesystemAdapter as LeagueLocalFilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\StorageAttributes;
+use League\Flysystem\SymbolicLinkEncountered;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\UnixVisibility\VisibilityConverter;
 use League\MimeTypeDetection\MimeTypeDetector;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SilverStripe\Core\Path;
+use SplFileInfo;
+use Throwable;
 
-class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter
+class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter implements GlobContentLister
 {
     private PathPrefixer $pathPrefixer;
+
+    private int $linkHandling;
+
+    private VisibilityConverter $visibility;
 
     public function __construct(
         string $location,
@@ -19,6 +37,8 @@ class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter
         ?MimeTypeDetector $mimeTypeDetector = null
     ) {
         $this->pathPrefixer = new PathPrefixer($location);
+        $this->linkHandling = $linkHandling;
+        $this->visibility = $visibility ??= new PortableVisibilityConverter();
 
         parent::__construct($location, $visibility, $writeFlags, $linkHandling, $mimeTypeDetector, false, true);
     }
@@ -26,5 +46,76 @@ class LocalFilesystemAdapter extends LeagueLocalFilesystemAdapter
     public function prefixPath(string $path): string
     {
         return $this->pathPrefixer->prefixPath($path);
+    }
+
+    /**
+     * List the contents of a path by glob.
+     *
+     * @return iterable<StorageAttributes>
+     */
+    public function listContentsByGlob(string $folder, string $fileGlob, bool $deep = FilesystemReader::LIST_SHALLOW): iterable
+    {
+        $basePath = $this->prefixPath($folder);
+        if (!is_dir($basePath)) {
+            return [];
+        }
+
+        // Use the glob to match the base path first.
+        yield from $this->findByGlob(Path::join($basePath, $fileGlob));
+
+        // If we're not checking subdirectories, just return out.
+        if (!$deep) {
+            return;
+        }
+
+        // Check contents of subdirectories recursively.
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $basePath,
+                FilesystemIterator::SKIP_DOTS | FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO
+            ),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        /** @var SplFileInfo $info */
+        foreach ($iterator as $path => $info) {
+            if ($info->isDir()) {
+                yield from $this->findByGlob(Path::join($path, $fileGlob));
+            }
+        }
+    }
+
+    private function findByGlob(string $glob): Generator
+    {
+        $iterator = new GlobIterator($glob, FilesystemIterator::SKIP_DOTS);
+        foreach ($iterator as $fileInfo) {
+            // NOTE: The contents of this loop are directly copied from listContents()
+            // except to remove `self` and to handle a private property
+            $pathName = $fileInfo->getPathname();
+            try {
+                if ($fileInfo->isLink()) {
+                    if ($this->linkHandling & LeagueLocalFilesystemAdapter::SKIP_LINKS) {
+                        continue;
+                    }
+                    throw SymbolicLinkEncountered::atLocation($pathName);
+                }
+
+                $path = $this->pathPrefixer->stripPrefix($pathName);
+                $lastModified = $fileInfo->getMTime();
+                $isDirectory = $fileInfo->isDir();
+                $permissions = octdec(substr(sprintf('%o', $fileInfo->getPerms()), -4));
+                $visibility = $isDirectory ? $this->visibility->inverseForDirectory($permissions) : $this->visibility->inverseForFile($permissions);
+
+                yield $isDirectory ? new DirectoryAttributes(str_replace('\\', '/', $path), $visibility, $lastModified) : new FileAttributes(
+                    str_replace('\\', '/', $path),
+                    $fileInfo->getSize(),
+                    $visibility,
+                    $lastModified
+                );
+            } catch (Throwable $exception) {
+                if (file_exists($pathName)) {
+                    throw $exception;
+                }
+            }
+        }
     }
 }

--- a/tests/php/FilenameParsing/HashFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/HashFileIDHelperTest.php
@@ -217,4 +217,38 @@ class HashFileIDHelperTest extends FileIDHelperTester
 
         $this->assertEquals($outFilename, $actualFilename);
     }
+
+    public static function provideGetVariantGlob(): array
+    {
+        return [
+            'folder is excluded' => [
+                'folder' => 'my-folder',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-file__*',
+            ],
+            'hash and folder are excluded' => [
+                'folder' => 'my-folder/123456789',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-file__*',
+            ],
+            'full folder path is excluded' => [
+                'folder' => 'my-folder/sub-folder/123456789',
+                'parsedFileID' => new ParsedFileID('my-folder/sub-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-file__*',
+            ],
+            'different folder gets ignored' => [
+                'folder' => 'different-folder/123456789',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-folder/my-file__*',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetVariantGlob')]
+    public function testGetVariantGlob(string $folder, ParsedFileID $parsedFileID, string $expected): void
+    {
+        $helper = new HashFileIDHelper();
+        $glob = $helper->getVariantGlob($folder, $parsedFileID);
+        $this->assertSame($expected, $glob);
+    }
 }

--- a/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/NaturalFileIDHelperTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace SilverStripe\Assets\Tests\FilenameParsing;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Assets\FilenameParsing\NaturalFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 
@@ -180,5 +181,39 @@ class NaturalFileIDHelperTest extends FileIDHelperTester
             [new ParsedFileID('folder/sam.jpg', 'abcdef7890'), 'folder'],
             [new ParsedFileID('folder/sam.jpg', 'abcdef7890', 'ResizeXXX'), 'folder'],
         ];
+    }
+
+    public static function provideGetVariantGlob(): array
+    {
+        return [
+            'folder is excluded' => [
+                'folder' => 'my-folder',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-file__*',
+            ],
+            'hash is not accounted for' => [
+                'folder' => 'my-folder/123456789',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-folder/my-file__*',
+            ],
+            'full folder path is excluded' => [
+                'folder' => 'my-folder/sub-folder',
+                'parsedFileID' => new ParsedFileID('my-folder/sub-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-file__*',
+            ],
+            'different folder gets ignored' => [
+                'folder' => 'different-folder/123456789',
+                'parsedFileID' => new ParsedFileID('my-folder/my-file.jpg', '123456789'),
+                'expected' => 'my-folder/my-file__*',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetVariantGlob')]
+    public function testGetVariantGlob(string $folder, ParsedFileID $parsedFileID, string $expected): void
+    {
+        $helper = new NaturalFileIDHelper();
+        $glob = $helper->getVariantGlob($folder, $parsedFileID);
+        $this->assertSame($expected, $glob);
     }
 }

--- a/tests/php/Flysystem/FilesystemTest.php
+++ b/tests/php/Flysystem/FilesystemTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\Flysystem;
+
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Assets\Flysystem\Filesystem;
+use SilverStripe\Assets\Tests\Flysystem\FilesystemTest\DummyGlobbableAdapter;
+use SilverStripe\Dev\SapphireTest;
+
+class FilesystemTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public static function provideIsEmpty(): array
+    {
+        return [
+            'no folder exists' => [
+                'folder' => 'doesnt-exist',
+                'expected' => true,
+            ],
+            'folder is empty' => [
+                'folder' => 'empty-folder',
+                'expected' => true,
+            ],
+            'folder not empty' => [
+                'folder' => 'not-empty-folder',
+                'expected' => false,
+            ],
+            'folder not empty but subdir is' => [
+                'folder' => 'folder-with-empty-subfolder',
+                'expected' => false,
+            ],
+            'wierd scenario' => [
+                'folder' => 'folder-with-falsy-file',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideIsEmpty')]
+    public function testIsEmpty(string $folder, bool $expected): void
+    {
+        $root = vfsStream::setup(
+            'root',
+            null,
+            [
+                'empty-folder' => [],
+                'not-empty-folder' => [
+                  'file.txt' => 'I\'m a file'
+                ],
+                'folder-with-empty-subfolder' => [
+                    'empty-subfolder' => [],
+                ],
+                'folder-with-falsy-file' => [
+                    '0' => 'If you parse my filename as an int, I will be false'
+                ]
+            ]
+        );
+        $filesystem = new Filesystem(new LocalFilesystemAdapter($root->url()));
+        $this->assertSame($expected, $filesystem->isEmpty($folder));
+    }
+
+    public static function provideListContentsByGlob(): array
+    {
+        return [
+            'missing folder' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'missing-folder',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [],
+            ],
+            'glob all empty' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'empty-folder',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [],
+            ],
+            'glob all' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'folder-with-contents',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [
+                    'file.txt',
+                    'subfolder',
+                    'subfolder/subfile.txt',
+                    'subfolder/special-file1.blah',
+                    'subfolder/special-file2',
+                    'subfolder/another-file.txt',
+                    'subfolder/subsubfolder',
+                    'subfolder/subsubfolder/special-file3.txt',
+                    'more-file',
+                    'special-file4.txt',
+                ],
+            ],
+            'glob all, not deep' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'folder-with-contents',
+                'fileGlob' => '*',
+                'deep' => false,
+                'expectedFilePaths' => [
+                    'subfolder',
+                    'file.txt',
+                    'more-file',
+                    'special-file4.txt',
+                ],
+            ],
+            'glob by name' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'folder-with-contents',
+                'fileGlob' => 'special-file*',
+                'deep' => true,
+                'expectedFilePaths' => [
+                    'subfolder/special-file1.blah',
+                    'subfolder/special-file2',
+                    'subfolder/subsubfolder/special-file3.txt',
+                    'special-file4.txt',
+                ],
+            ],
+            'glob by name, not deep' => [
+                'adapterClass' => LocalFilesystemAdapter::class,
+                'folder' => 'folder-with-contents',
+                'fileGlob' => 'special-file*',
+                'deep' => false,
+                'expectedFilePaths' => [
+                    'special-file4.txt',
+                ],
+            ],
+            'uses adapter glob when possible' => [
+                'adapterClass' => DummyGlobbableAdapter::class,
+                'folder' => 'folder-with-contents',
+                'fileGlob' => 'special-file*',
+                'deep' => false,
+                'expectedFilePaths' => [
+                    'file1',
+                    'file2',
+                    'file3',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideListContentsByGlob')]
+    public function testListContentsByGlob(string $adapterClass, string $folder, string $fileGlob, bool $deep, array $expectedFilePaths): void
+    {
+        $root = vfsStream::setup(
+            'root',
+            null,
+            [
+                'empty-folder' => [],
+                'folder-with-contents' => [
+                  'file.txt' => 'I\'m a file',
+                  'subfolder' => [
+                    'subfile.txt' => 'Content goes here',
+                    'special-file1.blah' => 'This one is special',
+                    'special-file2' => 'This one is also special',
+                    'another-file.txt' => 'This one is not special',
+                    'subsubfolder' => [
+                        'special-file3.txt' => 'more special',
+                    ],
+                  ],
+                  'more-file' => 'ignore this file',
+                  'special-file4.txt' => 'wow how special',
+                ],
+            ]
+        );
+
+        $filesystem = new Filesystem(new $adapterClass($root->url()));
+        $contents = $filesystem->listContentsByGlob($folder, $fileGlob, $deep);
+        $fileNames = [];
+        foreach ($contents as $file) {
+            $fileNames[] = str_replace($folder . '/', '', $file->path());
+        }
+        // Use assertEqualsCanonicalizing instead of assertSame because the order doesn't matter.
+        $this->assertEqualsCanonicalizing($expectedFilePaths, $fileNames);
+    }
+}

--- a/tests/php/Flysystem/FilesystemTest/DummyGlobbableAdapter.php
+++ b/tests/php/Flysystem/FilesystemTest/DummyGlobbableAdapter.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\Flysystem\FilesystemTest;
+
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemReader;
+use SilverStripe\Assets\Flysystem\GlobContentLister;
+use SilverStripe\Dev\TestOnly;
+use League\Flysystem\FilesystemAdapter;
+
+/**
+ * A dummy globbably adapter that gives fixed results so we know it's being called when we expect
+ */
+class DummyGlobbableAdapter implements FilesystemAdapter, GlobContentLister, TestOnly
+{
+    public function listContentsByGlob(string $folder, string $fileGlob, bool $deep = FilesystemReader::LIST_SHALLOW): iterable
+    {
+        return [
+            new FileAttributes('file1'),
+            new FileAttributes('file2'),
+            new FileAttributes('file3'),
+        ];
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return false;
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return false;
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        // no-op
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        // no-op
+    }
+
+    public function read(string $path): string
+    {
+        return '';
+    }
+
+    public function readStream(string $path)
+    {
+        // no-op
+    }
+
+    public function delete(string $path): void
+    {
+        // no-op
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        // no-op
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        // no-op
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        // no-op
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return new FileAttributes('');
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return new FileAttributes('');
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        return new FileAttributes('');
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return new FileAttributes('');
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return [];
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        // no-op
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        // no-op
+    }
+
+    protected function doFetch(array $ids): iterable
+    {
+        return [];
+    }
+
+    protected function doHave(string $id): bool
+    {
+        return false;
+    }
+
+    protected function doClear(string $namespace): bool
+    {
+        return false;
+    }
+
+    protected function doDelete(array $ids): bool
+    {
+        return false;
+    }
+
+    protected function doSave(array $values, int $lifetime): array|bool
+    {
+        return false;
+    }
+}

--- a/tests/php/Flysystem/LocalFilesystemAdapterTest.php
+++ b/tests/php/Flysystem/LocalFilesystemAdapterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SilverStripe\Assets\Tests\Flysystem;
+
+use DirectoryIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Assets\Flysystem\LocalFilesystemAdapter;
+use SilverStripe\Core\Path;
+use SilverStripe\Dev\SapphireTest;
+
+class LocalFilesystemAdapterTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        // Set up the folders and files we expect for our test.
+        // We can't use the virtual filesystem provided by mikey179/vfsstream here
+        // because PHP's glob can't run on virtual or remote filesystems.
+        $baseDir = Path::join(__DIR__, 'LocalFilesystemAdapterTest');
+        mkdir(Path::join($baseDir, 'empty-folder'));
+        $folderWithContents = Path::join($baseDir, 'folder-with-contents');
+        mkdir($folderWithContents);
+        $subFolder = Path::join($folderWithContents, 'subfolder');
+        mkdir($subFolder);
+        file_put_contents(Path::join($folderWithContents, 'file.txt'), '');
+        file_put_contents(Path::join($folderWithContents, 'more-file'), '');
+        file_put_contents(Path::join($folderWithContents, 'special-file3.txt'), '');
+        file_put_contents(Path::join($subFolder, 'subfile.txt'), '');
+        file_put_contents(Path::join($subFolder, 'special-file1.blah'), '');
+        file_put_contents(Path::join($subFolder, 'special-file2'), '');
+        file_put_contents(Path::join($subFolder, 'another-file.txt'), '');
+        $subSubFolder = Path::join($subFolder, 'subsubfolder');
+        mkdir($subSubFolder);
+        file_put_contents(Path::join($subSubFolder, 'special-file4.txt'), '');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $baseDir = Path::join(__DIR__, 'LocalFilesystemAdapterTest');
+        $folderWithContents = Path::join($baseDir, 'folder-with-contents');
+        $subFolder = Path::join($folderWithContents, 'subfolder');
+        $subSubFolder = Path::join($subFolder, 'subsubfolder');
+        foreach ([$subSubFolder, $subFolder, $folderWithContents, $baseDir] as $dir) {
+            foreach (new DirectoryIterator($dir) as $file) {
+                if ($file->isFile() && !str_ends_with($file->getPathname(), '.gitkeep')) {
+                    unlink($file->getRealPath());
+                }
+            }
+        }
+        rmdir($subSubFolder);
+        rmdir($subFolder);
+        rmdir($folderWithContents);
+        rmdir(Path::join($baseDir, 'empty-folder'));
+        parent::tearDownAfterClass();
+    }
+
+    public static function provideListContentsByGlob(): array
+    {
+        return [
+            'missing folder' => [
+                'folder' => 'missing-folder',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [],
+            ],
+            'glob all empty' => [
+                'folder' => 'empty-folder',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [],
+            ],
+            'glob all' => [
+                'folder' => 'folder-with-contents',
+                'fileGlob' => '*',
+                'deep' => true,
+                'expectedFilePaths' => [
+                    'file.txt',
+                    'subfolder',
+                    'subfolder/subfile.txt',
+                    'subfolder/special-file1.blah',
+                    'subfolder/special-file2',
+                    'subfolder/another-file.txt',
+                    'subfolder/subsubfolder',
+                    'subfolder/subsubfolder/special-file4.txt',
+                    'more-file',
+                    'special-file3.txt',
+                ],
+            ],
+            'glob all, not deep' => [
+                'folder' => 'folder-with-contents',
+                'fileGlob' => '*',
+                'deep' => false,
+                'expectedFilePaths' => [
+                    'subfolder',
+                    'file.txt',
+                    'more-file',
+                    'special-file3.txt',
+                ],
+            ],
+            'glob by name' => [
+                'folder' => 'folder-with-contents',
+                'fileGlob' => 'special-file*',
+                'deep' => true,
+                'expectedFilePaths' => [
+                    'subfolder/special-file1.blah',
+                    'subfolder/special-file2',
+                    'subfolder/subsubfolder/special-file4.txt',
+                    'special-file3.txt',
+                ],
+            ],
+            'glob by name, not deep' => [
+                'folder' => 'folder-with-contents',
+                'fileGlob' => 'special-file*',
+                'deep' => false,
+                'expectedFilePaths' => [
+                    'special-file3.txt',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideListContentsByGlob')]
+    public function testListContentsByGlob(string $folder, string $fileGlob, bool $deep, array $expectedFilePaths): void
+    {
+        $adapter = new LocalFilesystemAdapter(Path::join(__DIR__, 'LocalFilesystemAdapterTest'));
+        $contents = $adapter->listContentsByGlob($folder, $fileGlob, $deep);
+        $fileNames = [];
+        foreach ($contents as $file) {
+            $fileNames[] = str_replace($folder . '/', '', $file->path());
+        }
+        // Use assertEqualsCanonicalizing instead of assertSame because the order doesn't matter.
+        $this->assertEqualsCanonicalizing($expectedFilePaths, $fileNames);
+    }
+}


### PR DESCRIPTION
This PR does a few things:

1. In `FlysystemAssetStore::truncateDirectory()`, check if the directory is empty more efficiently (see https://github.com/silverstripe/silverstripe-assets/pull/685#discussion_r2072868057 and new `Filesystem::isEmpty()` method)
2. ~~Call `FlysystemAssetStore::truncateDirectory()` less often (mostly useful for adapters that can't do the empty check efficiently, e.g. S3 adapter which gets 1000 files per paginated fetch)~~ now done in https://github.com/silverstripe/silverstripe-assets/pull/686
3. Look for variants using a glob match pattern, which boosts performance specifically for the local filesystem adapter. With any other adapter, developers are responsible for decorating the adapter with a subclass that implements `GlobContentLister` if they want performance gains. This would be possible with the FTP adapter for example but not with the AWS S3 adapter.

## TODO

- Tests (will do after rebase)

## Dependencies

Requires the following PRs to be merged first (they are currently included in this PR's changset but will be removed on rebase after those are merged into the base branch)

- https://github.com/silverstripe/silverstripe-assets/pull/686
- https://github.com/silverstripe/silverstripe-assets/pull/687

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/681