### PR TITLE
API Add constant for the filename variant separator.

### DIFF
--- a/src/FileNameFilter.php
+++ b/src/FileNameFilter.php
@@ -49,7 +49,7 @@ class FileNameFilter
     private static $default_replacements = [
         '/\s/' => '-', // remove whitespace
         '/[^-_A-Za-z0-9+.]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash, dot, and underscore
-        '/_{2,}/' => '_', // remove duplicate underscores (since `__` is variant separator)
+        '/_{2,}/' => '_', // remove duplicate underscores (since `__` is variant separator - see FileIDHelper::VARIANT_SEPARATOR)
         '/-{2,}/' => '-', // remove duplicate dashes
         '/^[-_\.]+/' => '', // Remove all leading dots, dashes or underscores
     ];

--- a/src/FilenameParsing/AbstractFileIDHelper.php
+++ b/src/FilenameParsing/AbstractFileIDHelper.php
@@ -63,7 +63,7 @@ abstract class AbstractFileIDHelper implements FileIDHelper
 
         // Add variant
         if ($variant) {
-            $fileID .= '__' . $variant;
+            $fileID .= FileIDHelper::VARIANT_SEPARATOR . $variant;
         }
 
         // Add extension

--- a/src/FilenameParsing/FileIDHelper.php
+++ b/src/FilenameParsing/FileIDHelper.php
@@ -8,6 +8,12 @@ namespace SilverStripe\Assets\FilenameParsing;
 interface FileIDHelper
 {
     /**
+     * The string that separates the base file name from the variant name.
+     * This string must not be present in the name of files which are not variants.
+     */
+    public const VARIANT_SEPARATOR = '__';
+
+    /**
      * Map file tuple (hash, name, variant) to a filename to be used by flysystem
      *
      * @param string|ParsedFileID $filename Name of file or ParsedFileID object

--- a/src/FilenameParsing/HashFileIDHelper.php
+++ b/src/FilenameParsing/HashFileIDHelper.php
@@ -22,7 +22,9 @@ class HashFileIDHelper extends AbstractFileIDHelper
 
     public function parseFileID($fileID)
     {
-        $pattern = '#^(?<folder>([^/]+/)*)(?<hash>[a-f0-9]{10})/(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
+        $pattern = '#^(?<folder>([^/]+/)*)(?<hash>[a-f0-9]{10})/(?<basename>((?<!'
+            . FileIDHelper::VARIANT_SEPARATOR . ')[^/.])+)('
+            . FileIDHelper::VARIANT_SEPARATOR . '(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
 
         // not a valid file (or not a part of the filesystem)
         if (!preg_match($pattern ?? '', $fileID ?? '', $matches)) {

--- a/src/FilenameParsing/NaturalFileIDHelper.php
+++ b/src/FilenameParsing/NaturalFileIDHelper.php
@@ -13,7 +13,9 @@ class NaturalFileIDHelper extends AbstractFileIDHelper
 {
     public function parseFileID($fileID)
     {
-        $pattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!__)[^/.])+)(__(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
+        $pattern = '#^(?<folder>([^/]+/)*)(?<basename>((?<!'
+            . FileIDHelper::VARIANT_SEPARATOR . ')[^/.])+)('
+            . FileIDHelper::VARIANT_SEPARATOR . '(?<variant>[^.]+))?(?<extension>(\..+)*)$#';
 
         // not a valid file (or not a part of the filesystem)
         if (!preg_match($pattern ?? '', $fileID ?? '', $matches) || strpos($matches['folder'] ?? '', '_resampled') !== false) {


### PR DESCRIPTION
The variant separator in asset file names is hardcoded currently, which can lead to several problems including:
- human error (use wrong number of underscores)
- lack of discoverability (what was the separator again?)
- maintenance burden (what if we want to change it in a major?)

The new constant solves all those problems, along with making it easier to enforce this naming convention in the future if we want to.

The separator is used several new times in https://github.com/silverstripe/silverstripe-assets/pull/685 so adding a const to reference it seemed prudent.
Done in a separate PR to make it easier to review.

## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/681