### PR TITLE
FIX Return correct type

### DIFF
--- a/src/InterventionBackend.php
+++ b/src/InterventionBackend.php
@@ -319,7 +319,7 @@ class InterventionBackend implements Image_Backend, Flushable
 
             return $result;
         } catch (EncoderException $e) {
-            return null;
+            return [];
         }
     }
 


### PR DESCRIPTION
This method requires an array to be returned, not null.

Without this change, uploading SVG files results in an error if you have the following configuration:

```yaml
SilverStripe\Assets\File:
  file_types:
    svg: 'SVG Datei'
  allowed_extensions:
      - svg
  app_categories:
    image/supported:
      - svg
  class_for_file_extension:
    svg: 'SilverStripe\Assets\Image'

SilverStripe\Assets\Storage\DBFile:
  supported_images:
    - 'image/svg+xml'    
```

## Issue

- https://github.com/silverstripe/silverstripe-asset-admin/issues/1571