### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/template-engine": "^1",
         "symfony/filesystem": "^7.0",
         "symfony/finder": "^7.0",

--- a/src/Shortcodes/FileShortcodeProvider.php
+++ b/src/Shortcodes/FileShortcodeProvider.php
@@ -193,7 +193,7 @@ class FileShortcodeProvider implements ShortcodeHandler, Flushable
         }
 
         // Check if the file is found
-        $file = DataObject::get_by_id(File::class, $args['id']);
+        $file = DataObject::get(File::class)->setUseCache(true)->byID($args['id']);
         if (!$file) {
             $errorCode = 404;
             return null;

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -54,7 +54,7 @@ class FileTest extends SapphireTest
         );
         foreach ($fileIDs as $fileID) {
             /** @var File $file */
-            $file = DataObject::get_by_id(File::class, $fileID);
+            $file = DataObject::get(File::class)->setUseCache(true)->byID($fileID);
             $file->setFromString(str_repeat('x', 1000000), $file->getFilename());
         }
 
@@ -538,13 +538,13 @@ class FileTest extends SapphireTest
         //rename a folder's title
         $folderID = $this->objFromFixture(Folder::class, "folder2")->ID;
         /** @var Folder $folder */
-        $folder = DataObject::get_by_id(Folder::class, $folderID);
+        $folder = Folder::get()->byID($folderID);
         $folder->Title = $newTitle;
         $folder->write();
 
         //get folder again and see if the filename has changed
         /** @var Folder $folder */
-        $folder = DataObject::get_by_id(Folder::class, $folderID);
+        $folder = Folder::get()->byID($folderID);
         $this->assertEquals(
             $newTitle . '/',
             $folder->getFilename(),
@@ -558,7 +558,7 @@ class FileTest extends SapphireTest
 
         //get folder again and see if the Title has changed
         /** @var Folder $folder */
-        $folder = DataObject::get_by_id(Folder::class, $folderID);
+        $folder = Folder::get()->byID($folderID);
         $this->assertEquals(
             $folder->Title,
             $newTitle2,
@@ -572,7 +572,7 @@ class FileTest extends SapphireTest
         $folder->write();
 
         //get folder again and see if the Title has changed
-        $folder = DataObject::get_by_id(Folder::class, $folderID);
+        $folder = Folder::get()->byID($folderID);
         $this->assertEquals(
             $folder->Title,
             $newTitle3,

--- a/tests/php/FolderTest.php
+++ b/tests/php/FolderTest.php
@@ -9,7 +9,6 @@ use SilverStripe\Assets\FolderNameFilter;
 use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\InheritedPermissions;
 use SilverStripe\Security\Member;
@@ -135,12 +134,7 @@ class FolderTest extends SapphireTest
             'Empty folder does not have a filesystem record automatically'
         );
 
-        $parentFolder = DataObject::get_one(
-            Folder::class,
-            [
-            '"File"."Name"' => 'parent'
-            ]
-        );
+        $parentFolder = Folder::get()->find('Name', 'parent');
         $this->assertNotNull($parentFolder);
         $this->assertEquals($parentFolder->ID, $folder->ParentID);
 
@@ -172,7 +166,7 @@ class FolderTest extends SapphireTest
 
         // Publish file1
         /** @var File $file1 */
-        $file1 = DataObject::get_by_id(File::class, $this->idFromFixture(File::class, 'file1-folder1'), false);
+        $file1 = File::get()->byID($this->idFromFixture(File::class, 'file1-folder1'));
         $file1->publishRecursive();
 
         // set ParentID. This should cause updateFilesystem to be called on all children
@@ -232,20 +226,14 @@ class FolderTest extends SapphireTest
      */
     public function testRenameFolderAndCheckTheFile()
     {
-        // ID is prefixed in case Folder is subclassed by project/other module.
-        $folder1 = DataObject::get_one(
-            Folder::class,
-            [
-            '"File"."ID"' => $this->idFromFixture(Folder::class, 'folder1')
-            ]
-        );
+        $folder1 = Folder::get()->byID($this->idFromFixture(Folder::class, 'folder1'));
 
         $folder1->Name = 'FileTest-folder1-changed';
         $folder1->write();
 
         // Check if the file in the folder moved along
         /** @var File $file1 */
-        $file1 = DataObject::get_by_id(File::class, $this->idFromFixture(File::class, 'file1-folder1'), false);
+        $file1 = File::get()->byID($this->idFromFixture(File::class, 'file1-folder1'));
         $this->assertFileExists(
             TestAssetStore::getLocalPath($file1)
         );
@@ -315,13 +303,13 @@ class FolderTest extends SapphireTest
         $writeFolder = new Folder();
         $writeFolder->Name = 'TestNameWrittenToTitle';
         $writeFolder->write();
-        $newFolderWritten = Folder::get_one(Folder::class, "\"Title\" = 'TestNameWrittenToTitle'");
+        $newFolderWritten = Folder::get()->find('Title', 'TestNameWrittenToTitle');
         $this->assertNotNull($newFolderWritten);
 
         // Title should be populated from name on subsequent writes
         $writeFolder->Name = 'TestNameWrittenToTitleOnUpdate';
         $writeFolder->write();
-        $newFolderWritten = Folder::get_one(Folder::class, "\"Title\" = 'TestNameWrittenToTitleOnUpdate'");
+        $newFolderWritten = Folder::get()->find('Title', 'TestNameWrittenToTitleOnUpdate');
         $this->assertNotNull($newFolderWritten);
     }
 

--- a/tests/php/Shortcodes/FileShortcodeProviderTest.php
+++ b/tests/php/Shortcodes/FileShortcodeProviderTest.php
@@ -12,7 +12,6 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ErrorPage\ErrorPage;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\ShortcodeParser;
 
@@ -35,7 +34,7 @@ class FileShortcodeProviderTest extends SapphireTest
         );
         foreach ($fileIDs as $fileID) {
             /** @var File $file */
-            $file = DataObject::get_by_id(File::class, $fileID);
+            $file = File::get()->byID($fileID);
             $file->setFromString(str_repeat('x', 1000000), $file->getFilename());
         }
 


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Tests have been updated to remove caching where it's not relevant to the test.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
