### PR TITLE
ENH Use a generated column with functional index

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/template-engine": "^1",
         "symfony/filesystem": "^7.0",
         "symfony/finder": "^7.0",

--- a/src/File.php
+++ b/src/File.php
@@ -144,6 +144,14 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
         "File" => "DBFile",
         // Only applies to files, doesn't inherit for folder
         'ShowInSearch' => 'Boolean(1)',
+        // FQCN needs 4 backslashes so the raw SQL ends up with a single escaped backslash in the string literal.
+        'IsFolder' => <<<'SPEC'
+            Generated(
+                "Boolean",
+                "CASE WHEN \"ClassName\"='SilverStripe\\\\Assets\\\\Folder' THEN 1 ELSE 0 END",
+                "STORED"
+            )
+            SPEC,
     ];
 
     private static $has_one = [
@@ -160,7 +168,24 @@ class File extends DataObject implements AssetContainer, Thumbnail, CMSPreviewab
     ];
 
     private static $indexes = [
-        'FileHash' => true
+        'FileHash' => true,
+        // Used when viewing files in AssetAdmin ordered by Title ASC
+        // Not used for other sort (e.g. Title DESC or Created) so if the default
+        // sort in AssetAdmin changes, we should update this index.
+        'default_asset_sort' => [
+            'type' => 'index',
+            'columns' => [
+                'ParentID',
+                'IsFolder DESC',
+                'Title',
+            ],
+        ]
+    ];
+
+    private static bool|array $skip_fetch_generated_columns_after_write = [
+        // Updating the ClassName which this is based on is very unlikely,
+        // so we can skip the extra SELECT query after write.
+        'IsFolder',
     ];
 
     private static $defaults = [


### PR DESCRIPTION
This case statement is used to ensure folders appear before files in AssetAdmin. Adding this generated column and an associated index speeds up the default sort scenario for AssetAdmin.

We can't just use `ClassName` in the index here because the DB won't use it.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11774 for CI to go green


## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/693