### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/FilenameParsing/HashFileIDHelperTest.php
+++ b/tests/php/FilenameParsing/HashFileIDHelperTest.php
@@ -199,7 +199,6 @@ class HashFileIDHelperTest extends FileIDHelperTester
     {
         $helper = new HashFileIDHelper();
         $reflectionMethod = new ReflectionMethod($helper, 'swapExtension');
-        $reflectionMethod->setAccessible(true);
         $reflectionConst = new ReflectionClassConstant($helper, 'EXTENSION_VARIANT');
         $actualFilename = $reflectionMethod->invoke($helper, $inFilename, $variant, $reflectionConst->getValue());
 
@@ -211,7 +210,6 @@ class HashFileIDHelperTest extends FileIDHelperTester
     {
         $helper = new HashFileIDHelper();
         $reflectionMethod = new ReflectionMethod($helper, 'swapExtension');
-        $reflectionMethod->setAccessible(true);
         $reflectionConst = new ReflectionClassConstant($helper, 'EXTENSION_ORIGINAL');
         $actualFilename = $reflectionMethod->invoke($helper, $inFilename, $variant, $reflectionConst->getValue());
 

--- a/tests/php/Storage/Sha1FileHashingServiceTest.php
+++ b/tests/php/Storage/Sha1FileHashingServiceTest.php
@@ -248,7 +248,6 @@ class Sha1FileHashingServiceTest extends SapphireTest
             Sha1FileHashingService::class,
             'buildCacheKey'
         );
-        $reflectedMethod->setAccessible(true);
         // We're using this filename here as it was caught in issue #426
         $cacheKey = $reflectedMethod->invokeArgs(
             $service,

--- a/tests/php/UploadTest.php
+++ b/tests/php/UploadTest.php
@@ -188,7 +188,6 @@ class UploadTest extends SapphireTest
     {
         $v = new Upload_Validator();
         $reflectionMethod = new ReflectionMethod($v, 'maxUploadSizeFromPHPIni');
-        $reflectionMethod->setAccessible(true);
         $maxUploadSize = $reflectionMethod->invoke($v);
 
         // Bump up the size by about 2MB.
@@ -209,7 +208,6 @@ class UploadTest extends SapphireTest
     {
         $v = new Upload_Validator();
         $reflectionMethod = new ReflectionMethod($v, 'maxUploadSizeFromPHPIni');
-        $reflectionMethod->setAccessible(true);
         $maxUploadSize = $reflectionMethod->invoke($v);
 
         $v->setAllowedMaxFileSize([]);
@@ -223,7 +221,6 @@ class UploadTest extends SapphireTest
     {
         $v = new Upload_Validator();
         $reflectionMethod = new ReflectionMethod($v, 'maxUploadSizeFromPHPIni');
-        $reflectionMethod->setAccessible(true);
         $maxUploadSize = $reflectionMethod->invoke($v);
 
         /*


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.