### PR TITLE
ENH Cache mime type info to reduce memory usage

### DIFF
--- a/_config/assetscache.yml
+++ b/_config/assetscache.yml
@@ -2,6 +2,10 @@
 Name: assetscache
 ---
 SilverStripe\Core\Injector\Injector:
+  Psr\SimpleCache\CacheInterface.FlysystemAssetStore:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "FlysystemAssetStore"
   Psr\SimpleCache\CacheInterface.InterventionBackend_Manipulations:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:

--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -3,14 +3,12 @@
 namespace SilverStripe\Assets\Flysystem;
 
 use Exception;
-use Generator;
 use InvalidArgumentException;
 use LogicException;
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Util;
-use SilverStripe\Assets\FilenameParsing\FileIDHelper;
 use SilverStripe\Assets\FilenameParsing\FileResolutionStrategy;
-use SilverStripe\Assets\FilenameParsing\HashFileIDHelper;
 use SilverStripe\Assets\FilenameParsing\ParsedFileID;
 use SilverStripe\Assets\Storage\AssetNameGenerator;
 use SilverStripe\Assets\Storage\AssetStore;
@@ -63,6 +61,8 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
      * @var FileResolutionStrategy
      */
     private $protectedResolutionStrategy = null;
+
+    private ?CacheInterface $cache = null;
 
     /**
      * Flag if empty folders are allowed.
@@ -1124,13 +1124,23 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
 
     public function getMimeType($filename, $hash, $variant = null)
     {
+        // Flysystem calculates the mime type from the file contents, which is memory intensive, so we cache the result
+        $cache = $this->getCache();
+        $key = md5($filename . $hash . $variant);
+        if ($cache->has($key)) {
+            return $cache->get($key);
+        }
+
         // If `applyToFileOnFilesystem` calls our closure we'll know for sure that a file exists
-        return $this->applyToFileOnFilesystem(
+        $mimeType = $this->applyToFileOnFilesystem(
             function (ParsedFileID $parsedFileID, Filesystem $fs) {
                 return $fs->mimetype($parsedFileID->getFileID());
             },
             new ParsedFileID($filename, $hash, $variant)
         );
+
+        $cache->set($key, $mimeType);
+        return $mimeType;
     }
 
     public function exists($filename, $hash, $variant = null)
@@ -1276,6 +1286,24 @@ class FlysystemAssetStore implements AssetStore, AssetStoreRouter, Flushable
                 }
             }
         }
+
+        /** @var CacheInterface $cache */
+        $cache = Injector::inst()->get(CacheInterface::class . '.FlysystemAssetStore');
+        $cache->clear();
+    }
+
+    public function getCache(): CacheInterface
+    {
+        if (!$this->cache) {
+            $this->setCache(Injector::inst()->get(CacheInterface::class . '.FlysystemAssetStore'));
+        }
+        return $this->cache;
+    }
+
+    public function setCache(CacheInterface $cache): static
+    {
+        $this->cache = $cache;
+        return $this;
     }
 
     public function getResponseFor($asset)


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
This is a possible solution to #700 for discussion. The cache key includes the file hash, and I think it’s reasonable to expect that if someone updates the file in the filesystem manually, they’ll also update the hash in the database as there’s a bunch of logic throughout core that depends on that.

## Manual testing steps
XHProf, this snippet should be a reasonable benchmark:

```
<% loop $List('SilverStripe\Assets\Image').Limit(50) %>
	{$ScaleWidth('500')}<br />
<% end_loop %>
```
You should see a difference in wall time, memory usage and the number of function calls.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #700

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
