### PR TITLE
ENH Avoid loading already converted images into memory

### DIFF
--- a/src/Conversion/InterventionImageFileConverter.php
+++ b/src/Conversion/InterventionImageFileConverter.php
@@ -42,25 +42,31 @@ class InterventionImageFileConverter implements FileConverter
         if (!empty($problems)) {
             throw new FileConverterException('Invalid options provided: ' . implode(', ', $problems));
         }
-        $originalBackend = $from->getImageBackend();
-        if (!is_a($originalBackend, InterventionBackend::class)) {
-            $actualClass = $originalBackend ? get_class($originalBackend) : 'null';
-            throw new FileConverterException("ImageBackend must be an instance of InterventionBackend. Got $actualClass");
-        }
-        /** @var InterventionBackend $originalBackend */
-        $driver = $originalBackend->getImageManager()->driver();
-        if (!$driver->supports($toExtension)) {
-            throw new FileConverterException("Convertion to format '$toExtension' is not suported.");
+
+        if (!$from->exists()) {
+            throw new FileConverterException('Source file does not exist');
         }
 
-        $quality = $options['quality'] ?? null;
-        // Clone the backend if we're changing quality to avoid affecting other manipulations to that original image
-        $backend = $quality === null ? $originalBackend : clone $originalBackend;
         // Pass through to invervention image to do the conversion for us.
         try {
             $result = $from->manipulateExtension(
                 $toExtension,
-                function (AssetStore $store, string $filename, string $hash, string $variant) use ($backend, $quality) {
+                function (AssetStore $store, string $filename, string $hash, string $variant) use ($from, $toExtension, $options) {
+                    $originalBackend = $from->getImageBackend();
+                    if (!is_a($originalBackend, InterventionBackend::class)) {
+                        $actualClass = $originalBackend ? get_class($originalBackend) : 'null';
+                        throw new FileConverterException("ImageBackend must be an instance of InterventionBackend. Got $actualClass");
+                    }
+                    /** @var InterventionBackend $originalBackend */
+                    $driver = $originalBackend->getImageManager()->driver();
+                    if (!$driver->supports($toExtension)) {
+                        throw new FileConverterException("Convertion to format '$toExtension' is not suported.");
+                    }
+
+                    $quality = $options['quality'] ?? null;
+                    // Clone the backend if we're changing quality to avoid affecting other manipulations to that original image
+                    $backend = $quality === null ? $originalBackend : clone $originalBackend;
+
                     if ($quality !== null) {
                         $backend->setQuality($quality);
                     }

--- a/src/Conversion/InterventionImageFileConverter.php
+++ b/src/Conversion/InterventionImageFileConverter.php
@@ -60,7 +60,7 @@ class InterventionImageFileConverter implements FileConverter
                     /** @var InterventionBackend $originalBackend */
                     $driver = $originalBackend->getImageManager()->driver();
                     if (!$driver->supports($toExtension)) {
-                        throw new FileConverterException("Convertion to format '$toExtension' is not suported.");
+                        throw new FileConverterException("Conversion to format '$toExtension' is not supported.");
                     }
 
                     $quality = $options['quality'] ?? null;

--- a/tests/php/Conversion/InterventionImageFileConverterTest.php
+++ b/tests/php/Conversion/InterventionImageFileConverterTest.php
@@ -138,7 +138,7 @@ class InterventionImageFileConverterTest extends SapphireTest
                 'fromFixture' => 'missing-image',
                 'to' => 'png',
                 'options' => [],
-                'exceptionMessage' => 'ImageBackend must be an instance of InterventionBackend. Got null',
+                'exceptionMessage' => 'Source file does not exist',
             ],
             'nothing to convert to' => [
                 'fixtureClass' => Image::class,

--- a/tests/php/Conversion/InterventionImageFileConverterTest.php
+++ b/tests/php/Conversion/InterventionImageFileConverterTest.php
@@ -145,14 +145,14 @@ class InterventionImageFileConverterTest extends SapphireTest
                 'fromFixture' => 'jpg-image',
                 'to' => '',
                 'options' => [],
-                'exceptionMessage' => 'Convertion to format \'\' is not suported.',
+                'exceptionMessage' => 'Conversion to format \'\' is not supported.',
             ],
             'jpg to txt' => [
                 'fixtureClass' => Image::class,
                 'fromFixture' => 'jpg-image',
                 'to' => 'txt',
                 'options' => [],
-                'exceptionMessage' => 'Convertion to format \'txt\' is not suported.',
+                'exceptionMessage' => 'Conversion to format \'txt\' is not supported.',
             ],
             'txt to jpg' => [
                 'fixtureClass' => File::class,


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Split out from #702

By moving the extra code inside the closure, we can skip running it if the converted image already exists. Most other manipulations work this way already, I think this was just an oversight during implementation.

## Manual testing steps
Add this snippet:

```
<% loop $List('SilverStripe\Assets\Image').Limit(50) %>
	{$ScaleWidth('500').Convert('webp')}<br />
<% end_loop %>
```

Use XHProf to benchmark with/without this change, you should see a difference in wall time and the number of function calls.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #700

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
