### PR TITLE
FIX Fall back to icon for image preview link

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -110,7 +110,7 @@ class Image extends File
 
         // Temporarily disallow animated manipulations if necessary
         $backend = $this->getImageBackend();
-        $origAllowAnimation = $backend->getAllowsAnimationInManipulations();
+        $origAllowAnimation = $backend?->getAllowsAnimationInManipulations();
         if ($origAllowAnimation && !static::config()->get('allow_animated_preview')) {
             $backend->setAllowsAnimationInManipulations(false);
         }

--- a/tests/php/FileTest.php
+++ b/tests/php/FileTest.php
@@ -1273,4 +1273,34 @@ class FileTest extends SapphireTest
         $this->assertTrue(strpos($file1->getFilename(), 'FileTest-v2.pdf') !== false);
         $this->assertTrue(strpos($file2->getFilename(), 'FileTest.pdf') !== false);
     }
+
+    public static function providePreviewLink(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    #[DataProvider('providePreviewLink')]
+    public function testPreviewLink(bool $fileExists): void
+    {
+        $image = Image::create([
+            'Name' => 'animated.gif',
+            'FileFilename' => 'animated.gif',
+        ]);
+        $image->write();
+        if ($fileExists) {
+            $sourcePath = __DIR__ . '/ImageTest/' . $image->Name;
+            $image->setFromLocalFile($sourcePath, $image->Filename);
+        }
+        $image->publishSingle();
+
+        $previewLink = $image->PreviewLink();
+        if ($fileExists) {
+            $this->assertStringEndsWith('/assets/FileTest/animated__FitMaxWzkzMCwzMzZd.gif', $previewLink);
+        } else {
+            $this->assertStringContainsString('/_resources/vendor/silverstripe/framework/client/images/app_icons/generic_92.png', $previewLink);
+        }
+    }
 }


### PR DESCRIPTION
If no file existed in the filesystem, the backend was null which was causing this error:

> Uncaught Exception Error: "Call to a member function getAllowsAnimationInManipulations() on null" at /var/www/html/vendor/silverstripe/assets/src/Image.php line 113

We should fail gracefully here instead.

## Issue

- https://github.com/silverstripe/silverstripe-campaign-admin/issues/393